### PR TITLE
Fix conflict between parameter and local variable

### DIFF
--- a/src/circular.jl
+++ b/src/circular.jl
@@ -67,8 +67,8 @@ immutable FisherTLinearAssociation{S <: Real, T <: Real} <: HypothesisTest
 	phi::Vector{T}
 	uniformly_distributed::Union(Bool, Nothing)
 end
-function FisherTLinearAssociation{S <: Real, T <: Real}(theta::Vector{S},
-		phi::Vector{T}, uniformly_distributed::Union(Bool, Nothing))
+function FisherTLinearAssociation{Stheta <: Real, Sphi <: Real}(theta::Vector{Stheta},
+		phi::Vector{Sphi}, uniformly_distributed::Union(Bool, Nothing))
 	check_same_length(theta, phi)
 
 	A = sum(cos(theta).*cos(phi))


### PR DESCRIPTION
This fixes

```
Warning: local variable T conflicts with a static parameter in FisherTLinearAssociation at /home/tim/.julia/HypothesisTests/src/circular.jl:72.
```
