### PR TITLE
Fix kruskal wallis

### DIFF
--- a/src/kruskal_wallis.jl
+++ b/src/kruskal_wallis.jl
@@ -27,7 +27,7 @@ export KruskalWallisTest
 immutable KruskalWallisTest <: HypothesisTest
     n_i::Vector{Int}         # number of observations in each group
     df::Int                  # degrees of freedom
-    R_i::Vector{Int}         # rank sums
+    R_i::Vector{Float64}     # rank sums
     H::Float64               # test statistic: chi-square statistic
     tie_adjustment::Float64  # adjustment for ties
 end
@@ -67,7 +67,7 @@ function kwstats{T<:Real}(groups::AbstractVector{T}...)
     C = 1-tieadj/(n^3 - n)
 
     # compute rank sums
-    R_i = Array(Int, length(groups))
+    R_i = Array(Float64, length(groups))
     n_end = 0
     for i=1:length(groups)
         R_i[i] = sum(ranks[n_end+1:n_end+n_i[i]])

--- a/test/kruskal_wallis.jl
+++ b/test/kruskal_wallis.jl
@@ -29,3 +29,16 @@ t = HypothesisTests.KruskalWallisTest(city1, city2, city3, city4)
 @test_approx_eq t.tie_adjustment 0.9969565217391304
 @test_approx_eq pvalue(t) 0.0011186794961869423
 show(IOBuffer(), t)
+
+# example with non-integer rank sum
+t1 = [1.2,1.9,2.1]
+t2 = [3.4,1.9,5.6]
+t3 = [1.3,4.4,9.9]
+t = KruskalWallisTest(t1, t2, t3)
+@test t.n_i == [length(t1), length(t2), length(t3)]
+@test t.df == 2
+@test t.R_i ==  [9.5, 17.5, 18.0]
+@test_approx_eq t.H 2.039215686274513
+@test_approx_eq t.tie_adjustment 0.9916666666666667
+@test_approx_eq pvalue(t) 0.3607363776845705
+show(IOBuffer(), t)


### PR DESCRIPTION
Test throw an InexactError() because rank sum might be non-integer for ties.
