### PR TITLE
fisher.jl: Limit p-values to interval [0,1]

### DIFF
--- a/src/fisher.jl
+++ b/src/fisher.jl
@@ -56,13 +56,16 @@ end
 function pvalue(x::FisherExactTest; tail=:both, method=:central)
     if tail == :both && method != :central
         if method == :minlike
-            pvalue_both_minlike(x)
+            p = pvalue_both_minlike(x)
         else
             error("method=$(method) is not implemented yet")
         end
     else
-        pvalue(Hypergeometric(x.a + x.b, x.c + x.d, x.a + x.c), x.a, tail=tail)
+        p = pvalue(Hypergeometric(x.a + x.b, x.c + x.d, x.a + x.c), x.a, tail=tail)
     end
+    p = max(min(p, 1.0), 0.0)
+    
+    return p
 end
 
 function pvalue_both_minlike(x::FisherExactTest, ω::Float64=1.0)

--- a/test/fisher.jl
+++ b/test/fisher.jl
@@ -103,3 +103,7 @@ t = HypothesisTests.FisherExactTest(4, 1, 20, 1)
 @test_approx_eq [ci(t; method=:central)...] [0.002430190787475382, 19.59477744071154]
 #@test_approx_eq [ci(t; method=:minlike)...] [0.005, 9.5943]
 show(IOBuffer(), t)
+
+t = HypothesisTests.FisherExactTest(1, 1, 1, 1)
+@test HypothesisTests.pvalue(t, tail=:both) <= 1
+show(IOBuffer(), t)


### PR DESCRIPTION
Due to machine imprecision, the computed p-values can be outside this
interval.

Test case for issue #25 
