### PR TITLE
Fix compatability with DataArray/Frames

### DIFF
--- a/src/HypothesisTests.jl
+++ b/src/HypothesisTests.jl
@@ -29,7 +29,7 @@ using Distributions, Roots, StatsBase, Compat
 export testname, pvalue, ci
 abstract HypothesisTest
 
-check_same_length(x::Vector, y::Vector) = if length(x) != length(y)
+check_same_length(x::AbstractVector, y::AbstractVector) = if length(x) != length(y)
     throw(DimensionMismatch("Vectors must be the same length"))
 end
 


### PR DESCRIPTION
Change the arugment type declaration of check_same_length form Vector to
AbstractVector, which would enable the method to accept DataArray objects as
arguments.

More background:

I recently tried to use OneSampleTTest with data stored in a DataFrame (from the DataFrames package). An example being:
```
using DataFrames
df = DataFrame(x = [1, 2, 3], y = [4, 5, 6])

using HypothesisTests
OneSampleTTest(df[:x], df[:y])
```
which threw an error:
```
ERROR: `check_same_length` has no method matching 
    check_same_length(::DataArray{Int64,1}, ::DataArray{Int64,1}) 
in OneSampleTTest at ...
```
The check_same_length method is defined as the following:
```
check_same_length(x::Vector, y::Vector) = if length(x) != length(y)
    throw(DimensionMismatch("Vectors must be the same length"))
end
```
where ```Vector``` is an alias of ```Array{T,1}```.

It turns out ```Array``` and ```DataArray``` share the same parent type ```AbstractArray```. So by changing the type constraint to ```AbstractVector``` (which is an alias for ```AbstractArray{T, 1}```), we could enable the use of ```DataArray```s with the HypothesisTests package.


Note that the type ```Vector``` are also being used in a few other tests. Maybe we should change them to ```AbstractVector``` as well. However I have not tested those so I thought maybe someone who are more familiar with this package can fix those.