### PR TITLE
Fixed a bug when inverting the U-value in ExactMannWhitney

### DIFF
--- a/src/mann_whitney.jl
+++ b/src/mann_whitney.jl
@@ -79,8 +79,9 @@ end
 function mwuenumerate(x::ExactMannWhitneyUTest)
     # Get the other U if inverted by mwu_stats
     n = min(x.nx, x.ny)
+    U = x.U
     if x.ny > x.nx
-        U = x.nx*x.ny - U
+        U = x.nx*x.ny -x.U
     end
     le = 0
     gr = 0
@@ -89,8 +90,8 @@ function mwuenumerate(x::ExactMannWhitneyUTest)
     for comb in combinations(x.ranks, n)
         Up = sum(comb) - k
         tot += 1
-        le += Up <= x.U
-        gr += Up >= x.U
+        le += Up <= U
+        gr += Up >= U
     end
     (le/tot, gr/tot)
 end

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -15,6 +15,12 @@ show(IOBuffer(), ExactMannWhitneyUTest([1:10;], [2.1:2:21;]))
 @test abs(pvalue(ExactMannWhitneyUTest([1:5; ones(5)], [1:10;])) - 0.0057) <= 1e-4
 show(IOBuffer(), ExactMannWhitneyUTest([1:10;], [1:10;]))
 
+#Exact with ties and unequal lengths
+@test abs(pvalue(ExactMannWhitneyUTest([1:10;], [2:2:24;])) - 0.0118) <= 1e-4
+@test abs(pvalue(ExactMannWhitneyUTest([2:2:24;], [1:10;])) - 0.0118) <= 1e-4
+show(IOBuffer(), ExactMannWhitneyUTest([1:10;], [2:2:24;]))
+
+
 # Approximate test
 @test abs(pvalue(ApproximateMannWhitneyUTest([1:10;], [2.1:2:21;])) - 0.0257) <= 1e-4
 @test abs(pvalue(ApproximateMannWhitneyUTest([2.1:2:21;], [1:10;])) - 0.0257) <= 1e-4


### PR DESCRIPTION
I came across this while running some analysis and thought I'd try my hand at a fix. I included tests for the affected lines. Please let me know what needs to be changed/improved. Thanks!