### PR TITLE
Don't remove -Inf when computing the Anderson-Darling test statistic.

### DIFF
--- a/src/anderson_darling.jl
+++ b/src/anderson_darling.jl
@@ -12,11 +12,14 @@ function adstats{T<:Real}(x::AbstractVector{T}, d::UnivariateDistribution)
     y = sort(x)
     μ = mean(y)
     σ = std(y)
-    z = cdf(d, (y-μ)/σ)
-    i = 1:n
-    S = ((2*i-1.0)/n) .* (log(z[i])+log(1-z[n+1-i]))
-    S[isinf(S)] = 0. # remove infinity
-    A² = -n-sum(S)
+    A² = convert(typeof(μ), -n)
+    for i = 1:n
+        zi = (y[i] - μ)/σ
+        zni1 = (y[n - i + 1] - μ)/σ
+        lcdfz = logcdf(d, zi)
+        lccdfz = logccdf(d, zni1)
+        A² -= (2*i - 1)/n * (lcdfz + lccdfz)
+    end
     (n, μ, σ, A²)
 end
 
@@ -51,8 +54,10 @@ function pvalue(x::OneSampleADTest)
         1.0 - exp(-8.318+42.796z-59.938z^2)
     elseif .340 < z < .600
         exp(0.9177-4.279z-1.38z^2)
-    else
+    elseif z < 153.467
         exp(1.2937-5.709z+0.0186z^2)
+    else
+        0.0
     end
 end
 

--- a/test/anderson_darling.jl
+++ b/test/anderson_darling.jl
@@ -16,11 +16,11 @@ t = OneSampleADTest(x, Normal())
 
 x = rand(Cauchy(), n)
 t = OneSampleADTest(x, Normal())
-@test_approx_eq_eps t.A² 278.0190 0.1^4
+@test pvalue(t) < 1e-100
 
 x = rand(LogNormal(), n)
 t = OneSampleADTest(x, Normal())
-@test_approx_eq_eps t.A² 85.5217 0.1^4
+@test pvalue(t) < 1e-100
 
 # k-sample test
 samples = Any[
@@ -48,3 +48,5 @@ t = KSampleADTest(samples...)
 samples = Any[rand(Normal(), 50), rand(Normal(), 30), rand(Normal(), 20)]
 t = KSampleADTest(samples...)
 @test pvalue(t) > 0.05
+
+@test pvalue(OneSampleADTest(vcat(rand(Normal(),500), rand(Beta(2,2),500)), Beta(2,2))) == 0


### PR DESCRIPTION
These values occur when observations are outside the support of the
distribution for which we test against and is clearly against the null.
Therefore they should't be set to zero which is strongly in favor of
the null.

Also cut off the polynomial for very large values when computing the
p-values.

Avoid many Infs by using `logcdf` and `logccdf` instead of `log(cdf)` and
`log(1 - cdf)`.

Fixes #45 

cc: @wildart 