### PR TITLE
Fix undefined variable in SignedRankTest()

### DIFF
--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -30,7 +30,7 @@ export SignedRankTest, ExactSignedRankTest, ApproximateSignedRankTest
 function SignedRankTest{T<:Real}(x::AbstractVector{T})
     (W, ranks, signs, tie_adjustment, n, median) = signedrankstats(x)
     n_nonzero = length(ranks)
-    if n_nonzero <= 15 || (n_nonzero <= 50 && tieadj == 0)
+    if n_nonzero <= 15 || (n_nonzero <= 50 && tie_adjustment == 0)
         ExactSignedRankTest(W, ranks, signs, tie_adjustment, n, median)
     else
         ApproximateSignedRankTest(W, ranks, signs, tie_adjustment, n, median)

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -34,3 +34,15 @@ show(IOBuffer(), ApproximateSignedRankTest([1:10;], [1:10;]))
 @test abs(pvalue(SignedRankTest([1:10;], [2:2:20;])) - 0.0020) <= 1e-4
 @test abs(pvalue(SignedRankTest([1:10;], [2:11;])) - 0.0020) <= 1e-4
 show(IOBuffer(), SignedRankTest([1:10;], [2:2:20;]))
+
+# One Sample tests
+# P-value computed using R wilcox.test
+@test abs(pvalue(SignedRankTest([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] - 10.1)) - 0.09460449) <= 1e-4
+# P-value computed using R wilcox.test
+@test abs(pvalue(SignedRankTest([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16] - 10.1)) - 0.1928101) <= 1e-4
+
+# One Sample tests with ties
+# P-value computed using R package exactRankTests wilcox.exact
+@test abs(pvalue(SignedRankTest([1,2,3,4,5,6,7,10,10,10,10,10,13,14,15] - 10.1)) - 0.04052734) <= 1e-4
+# P-value computed using R wilcox.test
+@test abs(pvalue(SignedRankTest([1,2,3,4,5,6,7,10,10,10,10,10,13,14,15,16] - 10.1)) - 0.1021964) <= 1e-4


### PR DESCRIPTION
`SignedRankTest(x::AbstractVector{T})` fails with the following error:

```
ERROR: LoadError: UndefVarError: tieadj not defined
 in SignedRankTest at /home/HPL/dstoeckel/.julia/v0.4/HypothesisTests/src/wilcoxon.jl:33
 in SignedRankTest at /home/HPL/dstoeckel/.julia/v0.4/HypothesisTests/src/wilcoxon.jl:39
 in anonymous at /home/HPL/dstoeckel/Documents/notebooks/Dissertation/Enrichment Evaluation/plots.jl:47
 in map at /home/HPL/dstoeckel/.julia/v0.4/DataFrames/src/groupeddataframe/grouping.jl:178
 in by at /home/HPL/dstoeckel/.julia/v0.4/DataFrames/src/groupeddataframe/grouping.jl:304
 in anonymous at /home/HPL/dstoeckel/Documents/notebooks/Dissertation/Enrichment Evaluation/plots.jl:46
 in map at /home/HPL/dstoeckel/.julia/v0.4/DataFrames/src/groupeddataframe/grouping.jl:178
```

It seems as if the `tieadj` variable was not renamed to `tie_adjustment`. This commit fixes that.