### PR TITLE
WIP: fix computation of g2 in PowerDivergenceTest

### DIFF
--- a/src/power_divergence.jl
+++ b/src/power_divergence.jl
@@ -149,7 +149,7 @@ function ci_sison_glaz(x::PowerDivergenceTest, alpha::Float64; skew_correct::Boo
     s1,s2,s3,s4 = mapslices(sum,m,1)
     z  = (x.n-s1)/sqrt(s2)
     g1 = s3/(s2^(3/2))
-    g2 = s4*(s2^2)
+    g2 = s4/(s2^2)
     
     poly = 1 + g1 * (z^3 - 3*z)/6 + g2*(z^4-6*z^2+3)/24 + g1^2 * (z^6 - 15*z^4 + 45*z^2 -15)/72
     f = poly*exp(-z^2/2)/(sqrt(2*pi))

--- a/test/power_divergence.jl
+++ b/test/power_divergence.jl
@@ -13,8 +13,8 @@ m = PowerDivergenceTest(d)
 @test_approx_eq m.thetahat [0.2763873775843308,0.1755531374682626,0.11860718171926006,0.08668842945230323,0.16974972796517954,0.17301414581066377]
 
 c = ci(m)
-c0 =
-[(0.23322451940515054,0.31882480957222203),(0.1323902792890823,0.21799056945615383),(0.0754443235400798,0.16104461370715129),(0.04352557127312297,0.12912586144019447),(0.12658686978599926,0.21218715995307078),(0.12985128763148351,0.21545157779855498)]
+c0 = [(0.25788901, 0.2955449), (0.15705477, 0.1947107), (0.10010881, 0.1377647), (0.06819006, 0.1058460), (0.15125136, 0.1889073), (0.15451578, 0.1921717)]
+
 
 [ @test_approx_eq c[i][1] c0[i][1] for i in 1:length(c)]
 [ @test_approx_eq c[i][2] c0[i][2] for i in 1:length(c)]
@@ -54,9 +54,9 @@ show(IOBuffer(), m)
 m = ChisqTest(d)
 m = MultinomialLRT(d)
 
-ci(m, method = :bootstrap) 
-ci(m, method = :bootstrap, tail=:left) 
-ci(m, method = :bootstrap, tail=:right) 
+ci(m, method = :bootstrap)
+ci(m, method = :bootstrap, tail=:left)
+ci(m, method = :bootstrap, tail=:right)
 
 ci(m, method = :gold)
 ci(m, method = :gold, tail=:left)
@@ -73,7 +73,7 @@ ci(m, method = :sison_glaz, tail=:right)
 
 @test_throws ArgumentError ci(m, method=:FOO)
 @test_throws ArgumentError ci(m, tail=:fox)
- 
+
 
 
 
@@ -86,13 +86,14 @@ m = PowerDivergenceTest(d)
 @test_approx_eq m.thetahat [0.3333333333333333,0.25,0.4166666666666667]
 
 c = ci(m)
-c0 = [(0.04999999999999999,0.5833301356192295),(0.0,0.49999680228589616),(0.13333333333333336,0.6666634689525628)]
+c0 = [(0.2166667, 0.4807308), (0.1333333, 0.3973975), (0.3000000, 0.5640642)]
+
 
 [ @test_approx_eq c[i][1] c0[i][1] for i in 1:length(c)]
 [ @test_approx_eq c[i][2] c0[i][2] for i in 1:length(c)]
 
 @test_approx_eq pvalue(m) 0.2865047968601901
-@test_approx_eq m.stat 2.5 
+@test_approx_eq m.stat 2.5
 @test_approx_eq m.df 2
 @test_approx_eq m.n 60
 @test_approx_eq m.residuals [0.0,-1.118033988749895,1.118033988749895]
@@ -126,9 +127,9 @@ show(IOBuffer(), m)
 m = ChisqTest(d)
 m = MultinomialLRT(d)
 
-ci(m, method = :bootstrap) 
-ci(m, method = :bootstrap, tail=:left) 
-ci(m, method = :bootstrap, tail=:right) 
+ci(m, method = :bootstrap)
+ci(m, method = :bootstrap, tail=:left)
+ci(m, method = :bootstrap, tail=:right)
 
 ci(m, method = :gold)
 ci(m, method = :gold, tail=:left)


### PR DESCRIPTION
The [May & Johnson (2000) SAS macro](https://www.researchgate.net/profile/William_Johnson9/publication/5142788_Constructing_Two-Sided_Simultaneous_Confidence_Intervals_for_Multinomial_Proportions_for_Small_Counts_in_a_Large_Number_of_Cells/links/0deec52a60bb3cdf50000000.pdf) (see page 14 of the pdf) from which this code is inspired defines `g2 = s4/(s2^2)` (with a division), not `g2 = s4*(s2^2)` (with a multiplication), as is also described in [Levin (1981)](http://projecteuclid.org/download/pdf_1/euclid.aos/1176345593) (see page 3 of the pdf). (The [MultinomialCI](https://cran.r-project.org/web/packages/MultinomialCI/index.html) package in R also has this right.)

I don't have access to Agresti (2007) from which the test code is inspired (according to the comments), but with this correction the tests fail on line 19 of `test/power_divergence.jl` (the confidence intervals). How were those tests constructed? Do the values come directly from Agresti (2007)?
