### PR TITLE
Updated docstring for binomial confidence intervals

### DIFF
--- a/src/binomial.jl
+++ b/src/binomial.jl
@@ -60,12 +60,13 @@ pvalue(x::BinomialTest; tail=:both) = pvalue(Binomial(x.n, x.p), x.x; tail=tail)
 ```julia
 function ci(x::HypothesisTest, alpha::Float64=0.05; tail=:both, method=:clopper_pearson)
 ```
-Compute a confidence interval with coverage 1-alpha for multinomial proportions using one of the following methods. Possible values for method are:
+Compute a confidence interval with coverage 1-alpha for binomial proportions using one of the following methods. Possible values for method are:
 
-Sison, Glaz intervals :sison_glaz (default):
-Bootstrap intervals :bootstrap :
-Quesenberry, Hurst intervals :quesenberry_hurst :
-Gold intervals :gold (Asymptotic simultaneous intervals):
+- Clopper-Pearson :clopper_pearson (default)
+- Agresti-Coull :agresti_coull
+- Jeffrey :jeffrey
+- Wald :wald
+- Wilson :wilson
 """
 function ci(x::BinomialTest, alpha::Float64=0.05; tail=:both, method=:clopper_pearson)
     check_alpha(alpha)


### PR DESCRIPTION
The existing docstring described the available confidence interval methods for power divergence test, not for the binomial test.

The new docstring now describes the binomial CI methods that are used.
