### PR TITLE
Correct P value default

### DIFF
--- a/src/power_divergence.jl
+++ b/src/power_divergence.jl
@@ -41,7 +41,7 @@ end
 # parameter of interest: name, value under h0, point estimate
 population_param_of_interest(x::PowerDivergenceTest) = ("Multinomial Probabilities", x.theta0, x.thetahat)
 
-pvalue(x::PowerDivergenceTest; tail=:right) = pvalue(Chisq(x.df),x.stat; tail=tail)
+pvalue(x::PowerDivergenceTest; tail=:both) = pvalue(Chisq(x.df),x.stat; tail=tail)
 
 function ci(x::PowerDivergenceTest, alpha::Float64=0.05; tail::Symbol=:both, method::Symbol=:sison_glaz, correct::Bool=true, bootstrap_iters::Int64=10000, GC::Bool=true)
   check_alpha(alpha)


### PR DESCRIPTION
This fixes a small bug with  χ² test... `show` calls `pvalue(test)` and expect `tail` to be `:both`

![image](https://cloud.githubusercontent.com/assets/2822757/16186937/d00611c4-36a3-11e6-965c-29ddccd042b9.png)
