### PR TITLE
Subtypes of HypothesisTest can have optional fields :tail and :alpha

### DIFF
--- a/src/HypothesisTests.jl
+++ b/src/HypothesisTests.jl
@@ -68,21 +68,16 @@ function check_alpha(alpha::Float64)
     end
 end
 
-function get_tail(test::HypothesisTest)
-    if :tail in fieldnames(test)
-        getfield(test, :tail)
+# Utility to get an optional field (e.g., :tail and :alpha)
+getfield(value::HypothesisTest, name::Symbol, default::Any) =
+    if name in fieldnames(value)
+        Base.getfield(value, name)
     else
-        default_tail(test)
+        default
     end
-end
 
-function get_alpha(test::HypothesisTest)
-    if :alpha in fieldnames(test)
-        getfield(test, :alpha)
-    else
-        0.05
-    end
-end
+get_tail(test::HypothesisTest) = getfield(test, :tail, default_tail(test))
+get_alpha(test::HypothesisTest) = getfield(test, :alpha, 0.05)
 
 # Utility for pretty-printing: Append white space so that length(with_trailing_whitespace(s)) = max(len, length(s))
 with_trailing_whitespace(s::String, len::Int) = s * join(repeat([" "], outer=max(len - length(s), 0)), "")

--- a/src/HypothesisTests.jl
+++ b/src/HypothesisTests.jl
@@ -68,6 +68,14 @@ function check_alpha(alpha::Float64)
     end
 end
 
+function get_tail(test::HypothesisTest)
+    if :tail in fieldnames(test)
+        getfield(test, :tail)
+    else
+        default_tail(test)
+    end
+end
+
 # Pretty-print
 function Base.show{T<:HypothesisTest}(io::IO, test::T)
     println(io, testname(test))
@@ -86,9 +94,9 @@ function Base.show{T<:HypothesisTest}(io::IO, test::T)
     println(io)
 
     # test summary
-    p = pvalue(test)
+    tail = get_tail(test)
+    p = pvalue(test, tail=tail)
     outcome = if p > 0.05 "fail to reject" else "reject" end
-    tail = default_tail(test)
     println(io, "Test summary:")
     println(io, "    outcome with 95% confidence: $outcome h_0")
     if tail == :both

--- a/src/HypothesisTests.jl
+++ b/src/HypothesisTests.jl
@@ -84,6 +84,9 @@ function get_alpha(test::HypothesisTest)
     end
 end
 
+# Utility for pretty-printing: Append white space so that length(with_trailing_whitespace(s)) = max(len, length(s))
+with_trailing_whitespace(s::String, len::Int) = s * join(repeat([" "], outer=max(len - length(s), 0)), "")
+
 # Pretty-print
 function Base.show{T<:HypothesisTest}(io::IO, test::T)
     println(io, testname(test))
@@ -93,13 +96,14 @@ function Base.show{T<:HypothesisTest}(io::IO, test::T)
 
     # population details
     has_ci = applicable(StatsBase.confint, test)
+    label_len = has_ci ? length(conf_string) + 21 : 22 # 21 is length of ' confidence interval:', 22 that of 'parameter of interest:'
     (param_name, param_under_h0, param_estimate) = population_param_of_interest(test)
     println(io, "Population details:")
-    println(io, "    parameter of interest:   $param_name")
-    println(io, "    value under h_0:         $param_under_h0")
-    println(io, "    point estimate:          $param_estimate")
+    println(io, "    $(with_trailing_whitespace("parameter of interest:", label_len)) $param_name")
+    println(io, "    $(with_trailing_whitespace("value under h_0", label_len)) $param_under_h0")
+    println(io, "    $(with_trailing_whitespace("point estimate", label_len)) $param_estimate")
     if has_ci
-        println(io, "    $conf_string confidence interval: $(StatsBase.confint(test))") # TODO indent all details like this one
+        println(io, "    $conf_string confidence interval: $(StatsBase.confint(test))")
     end
     println(io)
 
@@ -108,13 +112,14 @@ function Base.show{T<:HypothesisTest}(io::IO, test::T)
     p = pvalue(test, tail=tail)
     outcome = if p > get_alpha(test) "fail to reject" else "reject" end
     println(io, "Test summary:")
-    println(io, "    outcome with $conf_string confidence: $outcome h_0") # TODO indent all details like this one
+    label_len = length(conf_string) + 25 # 25 is length of 'outcome with  confidence:'
+    println(io, "    outcome with $conf_string confidence: $outcome h_0")
     if tail == :both
-        println(io, "    two-sided p-value:           $p")
+        println(io, "    $(with_trailing_whitespace("two-sided p-value:", label_len)) $p")
     elseif tail == :left || tail == :right
-        println(io, "    one-sided p-value:           $p")
+        println(io, "    $(with_trailing_whitespace("one-sided p-value:", label_len)) $p")
     else
-        println(io, "    p-value:                     $p")
+        println(io, "    $(with_trailing_whitespace("p-value:", label_len)) $p")
     end
     println(io)
 

--- a/src/augmented_dickey_fuller.jl
+++ b/src/augmented_dickey_fuller.jl
@@ -207,6 +207,7 @@ end
 testname(::ADFTest) = "Augmented Dickey-Fuller unit root test"
 population_param_of_interest(x::ADFTest) =
     ("coefficient on lagged non-differenced variable", 0, x.coef)
+default_tail(test::ADFTest) = :left
 
 function show_params(io::IO, x::ADFTest, ident)
     println(io, ident, "sample size in regression:          ", x.n)
@@ -215,4 +216,4 @@ function show_params(io::IO, x::ADFTest, ident)
     println(io, ident, "Critical values at 1%, 5%, and 10%: ", x.cv')
 end
 
-pvalue(x::ADFTest) = HypothesisTests.pvalue(Normal(0, 1), adf_pv_aux(x.stat, x.deterministic); tail=:left)
+pvalue(x::ADFTest; tail=default_tail(x)) = HypothesisTests.pvalue(Normal(0, 1), adf_pv_aux(x.stat, x.deterministic); tail=tail)

--- a/src/box_test.jl
+++ b/src/box_test.jl
@@ -71,7 +71,7 @@ function show_params(io::IO, x::BoxPierceTest, ident)
     println(io, ident, "Q statistic:                    ", x.Q)
 end
 
-pvalue(x::BoxPierceTest) = pvalue(Chisq(x.lag-x.dof), x.Q; tail=:right)
+pvalue(x::BoxPierceTest; tail=default_tail(x)) = pvalue(Chisq(x.lag-x.dof), x.Q; tail=tail)
 
 #Ljung-Box test
 
@@ -120,4 +120,4 @@ function show_params(io::IO, x::LjungBoxTest, ident)
     println(io, ident, "Q statistic:                    ", x.Q)
 end
 
-pvalue(x::LjungBoxTest) = pvalue(Chisq(x.lag-x.dof), x.Q; tail=:right)
+pvalue(x::LjungBoxTest; tail=default_tail(x)) = pvalue(Chisq(x.lag-x.dof), x.Q; tail=tail)

--- a/src/breusch_godfrey.jl
+++ b/src/breusch_godfrey.jl
@@ -76,4 +76,4 @@ function show_params(io::IO, x::BreuschGodfreyTest, ident)
     println(io, ident, "T*R^2 statistic:                ", x.BG)
 end
 
-pvalue(x::BreuschGodfreyTest) = pvalue(Chisq(x.lag), x.BG; tail=:right)
+pvalue(x::BreuschGodfreyTest; tail=default_tail(x)) = pvalue(Chisq(x.lag), x.BG; tail=tail)

--- a/src/circular.jl
+++ b/src/circular.jl
@@ -60,7 +60,10 @@ function show_params(io::IO, x::RayleighTest, ident="")
     println(io, ident, "test statistic:         $(x.Rbar^2 * x.n)")
 end
 
-function pvalue(x::RayleighTest)
+function pvalue(x::RayleighTest; tail=default_tail(x))
+    if tail != default_tail(x) # warn that tail is not used here
+        warn("tail=$tail has no effect on the computation of the p value")
+    end
     Z = x.Rbar^2 * x.n
     x.n > 1e6 ? exp(-Z) :
         exp(-Z)*(1+(2*Z-Z^2)/(4*x.n)-(24*Z - 132*Z^2 + 76*Z^3 - 9*Z^4)/(288*x.n^2))

--- a/src/jarque_bera.jl
+++ b/src/jarque_bera.jl
@@ -84,4 +84,4 @@ function show_params(io::IO, x::JarqueBeraTest, ident)
     println(io, ident, "JB statistic:                   ", x.JB)
 end
 
-pvalue(x::JarqueBeraTest) = pvalue(Chisq(2), x.JB; tail=:right)
+pvalue(x::JarqueBeraTest; tail=default_tail(x)) = pvalue(Chisq(2), x.JB; tail=tail)

--- a/src/kruskal_wallis.jl
+++ b/src/kruskal_wallis.jl
@@ -53,7 +53,7 @@ function show_params(io::IO, x::KruskalWallisTest, ident)
     println(io, ident, "adjustment for ties:                 ", x.tie_adjustment)
 end
 
-pvalue(x::KruskalWallisTest) = pvalue(Chisq(x.df), x.H; tail=:right)
+pvalue(x::KruskalWallisTest; tail=default_tail(x)) = pvalue(Chisq(x.df), x.H; tail=tail)
 
 
 ## helper

--- a/src/t.jl
+++ b/src/t.jl
@@ -33,13 +33,13 @@ pvalue(x::TTest; tail=:both) = pvalue(TDist(x.df), x.t; tail=tail)
 default_tail(test::TTest) = :both
 
 # confidence interval by inversion
-function StatsBase.confint(x::TTest, alpha::Float64=0.05; tail=:both)
+function StatsBase.confint(x::TTest, alpha::Float64=0.05; tail=get_tail(x))
     check_alpha(alpha)
 
     if tail == :left
-        (-Inf, StatsBase.confint(x, alpha*2)[2])
+        (-Inf, StatsBase.confint(x, alpha*2, tail=:both)[2]) # tail=:both required as recursive anchor
     elseif tail == :right
-        (StatsBase.confint(x, alpha*2)[1], Inf)
+        (StatsBase.confint(x, alpha*2, tail=:both)[1], Inf)
     elseif tail == :both
         q = quantile(TDist(x.df), 1-alpha/2)
         (x.xbar-q*x.stderr, x.xbar+q*x.stderr)
@@ -58,6 +58,7 @@ immutable OneSampleTTest <: TTest
     stderr::Real # empirical standard error
     t::Real      # t-statistic
     μ0::Real     # mean under h_0
+    tail::Symbol # :left, :right, or :both
 end
 
 testname(::OneSampleTTest) = "One sample t-test"
@@ -70,19 +71,19 @@ function show_params(io::IO, x::OneSampleTTest, ident="")
     println(io, ident, "empirical standard error: $(x.stderr)")
 end
 
-function OneSampleTTest(xbar::Real, stddev::Real, n::Int, μ0::Real=0)
+function OneSampleTTest(xbar::Real, stddev::Real, n::Int, μ0::Real=0; tail::Symbol=:both)
     stderr = stddev/sqrt(n)
     t = (xbar-μ0)/stderr
     df = n-1
-    OneSampleTTest(n, xbar, df, stderr, t, μ0)
+    OneSampleTTest(n, xbar, df, stderr, t, μ0, tail)
 end
 
-OneSampleTTest{T<:Real}(v::AbstractVector{T}, μ0::Real=0) = OneSampleTTest(mean(v), std(v), length(v), μ0)
+OneSampleTTest{T<:Real}(v::AbstractVector{T}, μ0::Real=0; tail::Symbol=:both) = OneSampleTTest(mean(v), std(v), length(v), μ0, tail=tail)
 
-function OneSampleTTest{T<:Real, S<:Real}(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0)
+function OneSampleTTest{T<:Real, S<:Real}(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0; tail::Symbol=:both)
     check_same_length(x, y)
 
-    OneSampleTTest(x - y, μ0)
+    OneSampleTTest(x - y, μ0, tail=tail)
 end
 
 
@@ -96,6 +97,7 @@ immutable EqualVarianceTTest <: TwoSampleTTest
     stderr::Real # empirical standard error
     t::Real      # t-statistic
     μ0::Real     # mean difference under h_0
+    tail::Symbol # :left, :right, or :both
 end
 
 function show_params(io::IO, x::TwoSampleTTest, ident="")
@@ -108,14 +110,14 @@ end
 testname(::EqualVarianceTTest) = "Two sample t-test (equal variance)"
 population_param_of_interest(x::TwoSampleTTest) = ("Mean difference", x.μ0, x.xbar) # parameter of interest: name, value under h0, point estimate
 
-function EqualVarianceTTest{T<:Real,S<:Real}(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0)
+function EqualVarianceTTest{T<:Real,S<:Real}(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0; tail::Symbol=:both)
     nx, ny = length(x), length(y)
     xbar = mean(x) - mean(y)
     stddev = sqrt(((nx - 1) * var(x) + (ny - 1) * var(y)) / (nx + ny - 2))
     stderr = stddev * sqrt(1/nx + 1/ny)
     t = (xbar - μ0) / stderr
     df = nx + ny - 2
-    EqualVarianceTTest(nx, ny, xbar, df, stderr, t, μ0)
+    EqualVarianceTTest(nx, ny, xbar, df, stderr, t, μ0, tail)
 end
 
 
@@ -129,16 +131,17 @@ immutable UnequalVarianceTTest <: TwoSampleTTest
     stderr::Real # empirical standard error
     t::Real      # t-statistic
     μ0::Real     # mean under h_0
+    tail::Symbol # :left, :right, or :both
 end
 
 testname(::UnequalVarianceTTest) = "Two sample t-test (unequal variance)"
 
-function UnequalVarianceTTest{T<:Real,S<:Real}(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0)
+function UnequalVarianceTTest{T<:Real,S<:Real}(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0; tail::Symbol=:both)
     nx, ny = length(x), length(y)
     xbar = mean(x)-mean(y)
     varx, vary = var(x), var(y)
     stderr = sqrt(varx/nx + vary/ny)
     t = (xbar-μ0)/stderr
     df = (varx / nx + vary / ny)^2 / ((varx / nx)^2 / (nx - 1) + (vary / ny)^2 / (ny - 1))
-    UnequalVarianceTTest(nx, ny, xbar, df, stderr, t, μ0)
+    UnequalVarianceTTest(nx, ny, xbar, df, stderr, t, μ0, tail)
 end

--- a/src/t.jl
+++ b/src/t.jl
@@ -33,7 +33,7 @@ pvalue(x::TTest; tail=:both) = pvalue(TDist(x.df), x.t; tail=tail)
 default_tail(test::TTest) = :both
 
 # confidence interval by inversion
-function StatsBase.confint(x::TTest, alpha::Float64=0.05; tail=get_tail(x))
+function StatsBase.confint(x::TTest, alpha::Float64=get_alpha(x); tail=get_tail(x))
     check_alpha(alpha)
 
     if tail == :left
@@ -59,6 +59,7 @@ immutable OneSampleTTest <: TTest
     t::Real      # t-statistic
     μ0::Real     # mean under h_0
     tail::Symbol # :left, :right, or :both
+    alpha::Real  # alpha value
 end
 
 testname(::OneSampleTTest) = "One sample t-test"
@@ -71,19 +72,21 @@ function show_params(io::IO, x::OneSampleTTest, ident="")
     println(io, ident, "empirical standard error: $(x.stderr)")
 end
 
-function OneSampleTTest(xbar::Real, stddev::Real, n::Int, μ0::Real=0; tail::Symbol=:both)
+function OneSampleTTest(xbar::Real, stddev::Real, n::Int, μ0::Real=0; tail::Symbol=:both, alpha::Real=0.05)
     stderr = stddev/sqrt(n)
     t = (xbar-μ0)/stderr
     df = n-1
-    OneSampleTTest(n, xbar, df, stderr, t, μ0, tail)
+    OneSampleTTest(n, xbar, df, stderr, t, μ0, tail, alpha)
 end
 
-OneSampleTTest{T<:Real}(v::AbstractVector{T}, μ0::Real=0; tail::Symbol=:both) = OneSampleTTest(mean(v), std(v), length(v), μ0, tail=tail)
+OneSampleTTest{T<:Real}(v::AbstractVector{T}, μ0::Real=0; tail::Symbol=:both, alpha::Real=0.05) =
+    OneSampleTTest(mean(v), std(v), length(v), μ0, tail=tail, alpha=alpha)
 
-function OneSampleTTest{T<:Real, S<:Real}(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0; tail::Symbol=:both)
+function OneSampleTTest{T<:Real, S<:Real}(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0;
+                        tail::Symbol=:both, alpha::Real=0.05)
     check_same_length(x, y)
 
-    OneSampleTTest(x - y, μ0, tail=tail)
+    OneSampleTTest(x - y, μ0, tail=tail, alpha=alpha)
 end
 
 
@@ -98,6 +101,7 @@ immutable EqualVarianceTTest <: TwoSampleTTest
     t::Real      # t-statistic
     μ0::Real     # mean difference under h_0
     tail::Symbol # :left, :right, or :both
+    alpha::Real  # alpha value
 end
 
 function show_params(io::IO, x::TwoSampleTTest, ident="")
@@ -110,14 +114,15 @@ end
 testname(::EqualVarianceTTest) = "Two sample t-test (equal variance)"
 population_param_of_interest(x::TwoSampleTTest) = ("Mean difference", x.μ0, x.xbar) # parameter of interest: name, value under h0, point estimate
 
-function EqualVarianceTTest{T<:Real,S<:Real}(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0; tail::Symbol=:both)
+function EqualVarianceTTest{T<:Real,S<:Real}(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0;
+                                             tail::Symbol=:both, alpha::Real=0.05)
     nx, ny = length(x), length(y)
     xbar = mean(x) - mean(y)
     stddev = sqrt(((nx - 1) * var(x) + (ny - 1) * var(y)) / (nx + ny - 2))
     stderr = stddev * sqrt(1/nx + 1/ny)
     t = (xbar - μ0) / stderr
     df = nx + ny - 2
-    EqualVarianceTTest(nx, ny, xbar, df, stderr, t, μ0, tail)
+    EqualVarianceTTest(nx, ny, xbar, df, stderr, t, μ0, tail, alpha)
 end
 
 
@@ -132,16 +137,18 @@ immutable UnequalVarianceTTest <: TwoSampleTTest
     t::Real      # t-statistic
     μ0::Real     # mean under h_0
     tail::Symbol # :left, :right, or :both
+    alpha::Real  # alpha value
 end
 
 testname(::UnequalVarianceTTest) = "Two sample t-test (unequal variance)"
 
-function UnequalVarianceTTest{T<:Real,S<:Real}(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0; tail::Symbol=:both)
+function UnequalVarianceTTest{T<:Real,S<:Real}(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0;
+                                               tail::Symbol=:both, alpha::Real=0.05)
     nx, ny = length(x), length(y)
     xbar = mean(x)-mean(y)
     varx, vary = var(x), var(y)
     stderr = sqrt(varx/nx + vary/ny)
     t = (xbar-μ0)/stderr
     df = (varx / nx + vary / ny)^2 / ((varx / nx)^2 / (nx - 1) + (vary / ny)^2 / (ny - 1))
-    UnequalVarianceTTest(nx, ny, xbar, df, stderr, t, μ0, tail)
+    UnequalVarianceTTest(nx, ny, xbar, df, stderr, t, μ0, tail, alpha)
 end


### PR DESCRIPTION
This enables the specification of tail (left/right/both) and alpha value in the constructors of HypothesisTest subtypes:

```julia
using HypothesisTests
EqualVarianceTTest(x, y, alpha=0.0025, tail=:right)
```

Since the additional arguments of the constructors are named arguments, nobody using this package has to change his constructor calls. Defaults are used so that the package works just as before when the optional arguments are not provided.

Currently, the new optional functionality of this pull request is only implemented for the t-tests. Other subtypes of HypothesisTest can easily follow the adaptations of `src/t.jl`.

I am looking forward to your comments!
Mirko