### PR TITLE
Drop 0.5 and macOS testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: julia
 os:
   - linux
-  - osx
 julia:
   - 0.6
   - nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 Distributions 0.10.0
 Roots
 StatsBase 0.9.0


### PR DESCRIPTION
Once this is merged, FemtoCleaner should jump in and fix everything.

I've removed macOS from the Travis testing matrix since its queue is ridiculous and we don't have any platform-specific code in this package.