### PR TITLE
Correct release badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 *HypothesisTests.jl* is a Julia package that implements a wide range of hypothesis tests.
 
 - **Current Release**:
-  [![HypothesisTests](http://pkg.julialang.org/badges/HypothesisTests.5.svg)
+  [![HypothesisTests](http://pkg.julialang.org/badges/HypothesisTests_0.5.svg)
   ](http://pkg.julialang.org/?pkg=HypothesisTests)
-  [![HypothesisTests](http://pkg.julialang.org/badges/HypothesisTests.6.svg)
+  [![HypothesisTests](http://pkg.julialang.org/badges/HypothesisTests_0.6.svg)
   ](http://pkg.julialang.org/?pkg=HypothesisTests)
 - **Build & Testing Status:**
   [![Build Status](https://travis-ci.org/JuliaStats/HypothesisTests.jl.svg?branch=master)


### PR DESCRIPTION
I missed this in the review of #109.

Note: CI skipped, remove [ci skip] from commit message upon squash-merge.