### PR TITLE
Cleanup work related to doc transition

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,3 +1,8 @@
 # HypothesisTests package
 
 This package implements several hypothesis tests in Julia.
+
+```@contents
+Pages = ["methods.md", "nonparametric.md", "parametric.md", "time_series.md"]
+Depth = 2
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,6 +3,6 @@
 This package implements several hypothesis tests in Julia.
 
 ```@contents
-Pages = ["methods.md", "nonparametric.md", "parametric.md", "time_series.md"]
+Pages = ["methods.md", "parametric.md", "nonparametric.md", "time_series.md"]
 Depth = 2
 ```

--- a/src/augmented_dickey_fuller.jl
+++ b/src/augmented_dickey_fuller.jl
@@ -46,7 +46,7 @@ Critical values and asymptotic p-values are computed based on response surface r
 following MacKinnon (2010) and MacKinnon (1994), respectively. These may differ slightly
 from those reported in other regression packages as different algorithms might be used.
 
-References
+# References
 
   * James G. MacKinnon, 2010, "Critical values for cointegration tests,"
     QED Working Paper No. 1227, 2010, [link](http://ideas.repec.org/p/qed/wpaper/1227.html).
@@ -54,7 +54,7 @@ References
     Unit-Root and Cointegration Tests", Journal of Business & Economic Statistics,
     Vol. 12, No. 2, pp. 167-176, [link](http://www.jstor.org/stable/1391481).
 
-External links
+# External links
 
   * [Augmented Dickey-Fuller test on Wikipedia](https://en.wikipedia.org/wiki/Augmented_Dickey–Fuller_test)
 """

--- a/src/binomial.jl
+++ b/src/binomial.jl
@@ -45,7 +45,7 @@ probability is not equal to `p`.
 
 Computed confidence intervals ([`confint`](@ref)) by default are Clopper-Pearson intervals.
 
-Implements: [`pvalue`](@ref), [`confint`](@ref)
+Implements: [`pvalue`](@ref), [`confint(::BinomialTest)`](@ref)
 """
 BinomialTest(x::AbstractVector{Bool}, p=0.5) =
     BinomialTest(sum(x), length(x), p)

--- a/src/box_test.jl
+++ b/src/box_test.jl
@@ -45,9 +45,9 @@ testing the residuals of an estimated model, `dof` has to be set to the number
 of estimated parameters. E.g., when testing the residuals of an ARIMA(p,0,q)
 model, set `dof=p+q`.
 
-External links
+# External links
 
-* [Box-Pierce test on Wikipedia](https://en.wikipedia.org/wiki/Ljung–Box_test#Box-Pierce_test)
+  * [Box-Pierce test on Wikipedia](https://en.wikipedia.org/wiki/Ljung–Box_test#Box-Pierce_test)
 """
 function BoxPierceTest(y::AbstractVector{T}, lag::Int, dof::Int=0) where T<:Real
     if dof>=lag
@@ -94,9 +94,9 @@ testing the residuals of an estimated model, `dof` has to be set to the number
 of estimated parameters. E.g., when testing the residuals of an ARIMA(p,0,q)
 model, set `dof=p+q`.
 
-External links
+# External links
 
-* [Ljung-Box test on Wikipedia](https://en.wikipedia.org/wiki/Ljung–Box_test)
+  * [Ljung-Box test on Wikipedia](https://en.wikipedia.org/wiki/Ljung–Box_test)
 """
 function LjungBoxTest(y::AbstractVector{T}, lag::Int, dof::Int=0) where T<:Real
     if dof>=lag

--- a/src/breusch_godfrey.jl
+++ b/src/breusch_godfrey.jl
@@ -42,9 +42,9 @@ Set `start0` to specify how the starting values for the lagged residuals are han
 `start0 = true` (default) sets them to zero (as in Godfrey, 1978); `start0 = false`
 uses the first `lag` residuals as starting values, i.e. shortening the sample by `lag`.
 
-External links
+# External links
 
-* [Breusch-Godfrey test on Wikipedia](https://en.wikipedia.org/wiki/Breusch–Godfrey_test)
+  * [Breusch-Godfrey test on Wikipedia](https://en.wikipedia.org/wiki/Breusch–Godfrey_test)
 """
 function BreuschGodfreyTest(xmat::AbstractArray{T}, e::AbstractVector{T},
                             lag::Int, start0::Bool=true) where T<:Real

--- a/src/durbin_watson.jl
+++ b/src/durbin_watson.jl
@@ -44,7 +44,8 @@ DW = \\frac{\\sum_{t=2}^n (e_t - e_{t-1})^2}{\\sum_{t=1}^n e_t^2}
 ```
 where `n` is the number of observations.
 
-By default, the choice of approach to compute p-values depends on the sample size (`p_compute=:ndep`). For small samples (n<100), Pan's algorithm (Farebrother, 1980) is
+By default, the choice of approach to compute p-values depends on the sample size
+(`p_compute=:ndep`). For small samples (n<100), Pan's algorithm (Farebrother, 1980) is
 employed. For larger samples, a normal approximation is used (Durbin and Watson, 1950). To
 always use Pan's algorithm, set `p_compute=:exact`. `p_compute=:approx` will always use the
 normal approximation.
@@ -57,21 +58,19 @@ and `:right` (positive serial correlation).
 # References
 
   * J. Durbin and G. S. Watson, 1951, "Testing for Serial Correlation in Least Squares
-  Regression: II", Biometrika, Vol. 38, No. 1/2, pp. 159-177,
-  [http://www.jstor.org/stable/2332325](http://www.jstor.org/stable/2332325).
+    Regression: II", Biometrika, Vol. 38, No. 1/2, pp. 159-177,
+    [http://www.jstor.org/stable/2332325](http://www.jstor.org/stable/2332325).
   * J. Durbin and G. S. Watson, 1950, "Testing for Serial Correlation in Least Squares
-  Regression: I", Biometrika, Vol. 37, No. 3/4, pp. 409-428,
-  [http://www.jstor.org/stable/2332391](http://www.jstor.org/stable/2332391).
+    Regression: I", Biometrika, Vol. 37, No. 3/4, pp. 409-428,
+    [http://www.jstor.org/stable/2332391](http://www.jstor.org/stable/2332391).
   * R. W. Farebrother, 1980, "Algorithm AS 153: Pan's Procedure for the Tail Probabilities
-  of the Durbin-Watson Statistic", Journal of the Royal Statistical Society, Series C
-  (Applied Statistics), Vol. 29, No. 2, pp. 224-227,
-  [http://www.jstor.org/stable/2986316](http://www.jstor.org/stable/2986316).
+    of the Durbin-Watson Statistic", Journal of the Royal Statistical Society, Series C
+    (Applied Statistics), Vol. 29, No. 2, pp. 224-227,
+    [http://www.jstor.org/stable/2986316](http://www.jstor.org/stable/2986316).
 
 # External links
 
-  * [Durbin-Watson test on Wikipedia:
-  https://en.wikipedia.org/wiki/Durbin–Watson_statistic
-  ](https://en.wikipedia.org/wiki/Durbin–Watson_statistic)
+  * [Durbin-Watson test on Wikipedia](https://en.wikipedia.org/wiki/Durbin–Watson_statistic)
 """
 function DurbinWatsonTest(xmat::AbstractArray{T}, e::AbstractArray{T};
     p_compute::Symbol = :ndep) where T<:Real

--- a/src/fisher.jl
+++ b/src/fisher.jl
@@ -43,7 +43,7 @@ The contingency table is structured as:
     odds ratio rather than the sample odds ratio; it maximizes the likelihood given by
     Fisher's non-central hypergeometric distribution.
 
-Implements: [`pvalue`](@ref), [`confint`](@ref)
+Implements: [`pvalue(::FisherExactTest)`](@ref), [`confint(::FisherExactTest)`](@ref)
 
 # References
 

--- a/src/power_divergence.jl
+++ b/src/power_divergence.jl
@@ -272,7 +272,7 @@ real number determining the nature of the test to be performed:
 Under regularity conditions, the asymptotic distributions are identical (see Drost et. al.
 1989). The ``χ^2`` null approximation works best for ``λ`` near ``2/3``.
 
-Implements: [`pvalue`](@ref), [`confint`](@ref)
+Implements: [`pvalue`](@ref), [`confint(::PowerDivergenceTest)`](@ref)
 
 # References
 


### PR DESCRIPTION
Two commits related to the documentation
1. Include a table of contents on the index page of the docs.
2. Fix assorted docstring issues.