### PR TITLE
Add Constructor to FisherExactTest

### DIFF
--- a/src/fisher.jl
+++ b/src/fisher.jl
@@ -26,10 +26,14 @@ export FisherExactTest
 
 """
     FisherExactTest(a::Integer, b::Integer, c::Integer, d::Integer)
+    FisherExactTest(x)
 
 Perform Fisher's exact test of the null hypothesis that the success probabilities ``a/c``
 and ``b/d`` are equal, that is the odds ratio ``(a/c) / (b/d)`` is one, against the
 alternative hypothesis that they are not equal.
+
+If `x` is a matrix with at least two rows and columns, it is taken as a two-dimensional
+contingency table.
 
 See [`pvalue(::FisherExactTest)`](@ref) and [`confint(::FisherExactTest)`](@ref) for details
 about the computation of the default p-value and confidence interval, respectively.
@@ -41,10 +45,11 @@ The contingency table is structured as:
 |*Y1*| a  | b  |
 |*Y2*| c  | d  |
 
-!!! note
+!!! Note:
     The `show` function output contains the conditional maximum likelihood estimate of the
     odds ratio rather than the sample odds ratio; it maximizes the likelihood given by
     Fisher's non-central hypergeometric distribution.
+    The entries must be non-negative integers.
 
 Implements: [`pvalue(::FisherExactTest)`](@ref), [`confint(::FisherExactTest)`](@ref)
 

--- a/src/fisher.jl
+++ b/src/fisher.jl
@@ -73,6 +73,10 @@ struct FisherExactTest <: HypothesisTest
     end
 end
 
+function FisherExactTest(x::AbstractMatrix{T}) where T<:Integer
+    FisherExactTest(x[1,1], x[1,2], x[2,1], x[2,2])
+end
+
 testname(::FisherExactTest) = "Fisher's exact test"
 population_param_of_interest(x::FisherExactTest) = ("Odds ratio", 1.0, x.ω) # parameter of interest: name, value under h0, point estimate
 default_tail(test::FisherExactTest) = :both


### PR DESCRIPTION
I recently reported an issue #154, since fisher's test works with contingency tables it would be expected to accept a matrix as argument, however it is not implemented. This commit resolves this problem.