### PR TITLE
Add sections for chi-squared and likelihood ratio tests in docs

### DIFF
--- a/docs/src/parametric.md
+++ b/docs/src/parametric.md
@@ -5,12 +5,12 @@
 PowerDivergenceTest
 ```
 
-### Pearson chi-squared test
+## Pearson chi-squared test
 ```@docs
 ChisqTest
 ```
 
-### Multinomial likelihood ratio test
+## Multinomial likelihood ratio test
 ```@docs
 MultinomialLRT
 ```


### PR DESCRIPTION
This makes them much easier to find in the homepage, as users do not
necessarily know that these are special cases of the power divergence test.