### PR TITLE
Rename some tests for consistency

### DIFF
--- a/docs/src/multivariate.md
+++ b/docs/src/multivariate.md
@@ -3,9 +3,9 @@
 ## Hotelling's ``T^2`` test
 
 ```@docs
-OneSampleHotellingT2
-EqualCovHotellingT2
-UnequalCovHotellingT2
+OneSampleHotellingT2Test
+EqualCovHotellingT2Test
+UnequalCovHotellingT2Test
 ```
 
 ## Equality of covariance matrices

--- a/docs/src/parametric.md
+++ b/docs/src/parametric.md
@@ -12,7 +12,7 @@ ChisqTest
 
 ### Multinomial likelihood ratio test
 ```@docs
-MultinomialLRT
+MultinomialLRTest
 ```
 
 ## t-test

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,3 +1,8 @@
 using Base: @deprecate
 
 @deprecate ci(args...) confint(args...)
+
+@deprecate MultinomialLRT MultinomialLRTest
+@deprecate OneSampleHotellingT2 OneSampleHotellingT2Test
+@deprecate EqualCovHotellingT2 EqualCovHotellingT2Test
+@deprecate UnequalCovHotellingT2 UnequalCovHotellingT2Test

--- a/src/power_divergence.jl
+++ b/src/power_divergence.jl
@@ -1,4 +1,4 @@
-export PowerDivergenceTest, ChisqTest, MultinomialLRT
+export PowerDivergenceTest, ChisqTest, MultinomialLRTest
 
 const Levels{T} = Tuple{UnitRange{T},UnitRange{T}}
 
@@ -380,9 +380,9 @@ end
 ChisqTest(x::AbstractVector{T}, theta0::Vector{U} = ones(length(x))/length(x)) where {T<:Integer,U<:AbstractFloat} =
     PowerDivergenceTest(reshape(x, length(x), 1), lambda=1.0, theta0=theta0)
 
-#MultinomialLRT
+#MultinomialLRTest
 """
-    MultinomialLRT(x[, y][, theta0 = ones(length(x))/length(x)])
+    MultinomialLRTest(x[, y][, theta0 = ones(length(x))/length(x)])
 
 Perform a multinomial likelihood ratio test (equivalent to a [`PowerDivergenceTest`](@ref)
 with ``λ = 0``).
@@ -403,21 +403,21 @@ Note that the entries of `x` (and `y` if provided) must be non-negative integers
 
 Implements: [`pvalue`](@ref), [`confint`](@ref)
 """
-function MultinomialLRT(x::AbstractMatrix{T}) where T<:Integer
+function MultinomialLRTest(x::AbstractMatrix{T}) where T<:Integer
     PowerDivergenceTest(x, lambda=0.0)
 end
 
-function MultinomialLRT(x::AbstractVector{T}, y::AbstractVector{T}, levels::Levels{T}) where T<:Integer
+function MultinomialLRTest(x::AbstractVector{T}, y::AbstractVector{T}, levels::Levels{T}) where T<:Integer
     d = counts(x, y, levels)
     PowerDivergenceTest(d, lambda=0.0)
 end
 
-function MultinomialLRT(x::AbstractVector{T}, y::AbstractVector{T}, k::T) where T<:Integer
+function MultinomialLRTest(x::AbstractVector{T}, y::AbstractVector{T}, k::T) where T<:Integer
     d = counts(x, y, k)
     PowerDivergenceTest(d, lambda=0.0)
 end
 
-MultinomialLRT(x::AbstractVector{T}, theta0::Vector{U} = ones(length(x))/length(x)) where {T<:Integer,U<:AbstractFloat} =
+MultinomialLRTest(x::AbstractVector{T}, theta0::Vector{U} = ones(length(x))/length(x)) where {T<:Integer,U<:AbstractFloat} =
     PowerDivergenceTest(reshape(x, length(x), 1), lambda=0.0, theta0=theta0)
 
 function show_params(io::IO, x::PowerDivergenceTest, ident="")

--- a/test/hotelling.jl
+++ b/test/hotelling.jl
@@ -40,7 +40,7 @@ end
     # Columns are calcium, iron, protein, vitamin A, vitamin C
     nutrient = readdlm(joinpath(@__DIR__, "data", "nutrient.txt"))[:,2:end]
 
-    t = OneSampleHotellingT2(nutrient, [1000, 15, 60, 800, 75])
+    t = OneSampleHotellingT2Test(nutrient, [1000, 15, 60, 800, 75])
     @test nobs(t) == 737
     @test dof(t) == (5, 732)
     @test pvalue(t) ≈ 0.0 atol=eps()
@@ -54,7 +54,7 @@ end
     spouse = readdlm(joinpath(@__DIR__, "data", "spouse.txt"))
 
     # Paired
-    p = OneSampleHotellingT2(spouse[:,1:4], spouse[:,5:end])
+    p = OneSampleHotellingT2Test(spouse[:,1:4], spouse[:,5:end])
     @test nobs(p) == 30
     @test dof(p) == (4, 26)
     @test pvalue(p) ≈ 0.039369144 atol=1e-6
@@ -71,7 +71,7 @@ end
     genuine = convert(Matrix{Float64}, swiss[view(swiss, :, 1) .== "real", 2:end])
     counterfeit = convert(Matrix{Float64}, swiss[view(swiss, :, 1) .== "fake", 2:end])
 
-    eq = EqualCovHotellingT2(genuine, counterfeit)
+    eq = EqualCovHotellingT2Test(genuine, counterfeit)
     @test nobs(eq) == (100, 100)
     @test dof(eq) == (6, 193)
     @test pvalue(eq) ≈ 0.0 atol=eps()
@@ -79,7 +79,7 @@ end
     @test eq.F ≈ 391.9217023 atol=1e-6
     @test occursin("reject h_0", sprint(show, eq))
 
-    un = UnequalCovHotellingT2(genuine, counterfeit)
+    un = UnequalCovHotellingT2Test(genuine, counterfeit)
     @test nobs(un) == (100, 100)
     @test dof(un) == (6, 193)
     @test pvalue(un) ≈ 0.0 atol=eps()

--- a/test/power_divergence.jl
+++ b/test/power_divergence.jl
@@ -60,7 +60,7 @@ pvalue(m)
 show(IOBuffer(), m)
 
 m = ChisqTest(d)
-m = MultinomialLRT(d)
+m = MultinomialLRTest(d)
 
 confint(m, method = :bootstrap)
 confint(m, method = :bootstrap, tail=:left)
@@ -136,7 +136,7 @@ pvalue(m)
 show(IOBuffer(), m)
 
 m = ChisqTest(d)
-m = MultinomialLRT(d)
+m = MultinomialLRTest(d)
 
 confint(m, method = :bootstrap)
 confint(m, method = :bootstrap, tail=:left)
@@ -165,7 +165,7 @@ y=[1,1,1,2,2,3]
 d = counts(x,y,3)
 
 ChisqTest(d)
-MultinomialLRT(d)
+MultinomialLRTest(d)
 
 PowerDivergenceTest(x,y,3)
 PowerDivergenceTest(x,y,(1:3,1:3))
@@ -173,8 +173,8 @@ PowerDivergenceTest(x,y,(1:3,1:3))
 ChisqTest(x,y,3)
 ChisqTest(x,y,(1:3,1:3))
 
-MultinomialLRT(x,y,3)
-MultinomialLRT(x,y,(1:3,1:3))
+MultinomialLRTest(x,y,3)
+MultinomialLRTest(x,y,(1:3,1:3))
 
 # Test that large counts don't cause overflow (issue #43)
 d = [113997 1031298


### PR DESCRIPTION
MultinomialLRT and the three *HotellingT2 were the only tests whose names did not end with "Test".