### PR TITLE
Allow Travis failures on Julia nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,30 @@
 # Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
+
 os:
   - linux
+
 julia:
   - 0.7
   - 1.0
   - 1.1
   - nightly
+
+matrix:
+  allow_failures:
+    - julia: nightly
+
 notifications:
   email: false
+
 # uncomment the following lines to override the default test script
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("HypothesisTests"); Pkg.test("HypothesisTests"; coverage=true)'
+
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+
 jobs:
   include:
     - stage: "Documentation"


### PR DESCRIPTION
The failure currently blocks deploying Documenter manual.