### PR TITLE
Use strict version bounds for dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,10 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-StatsBase = ">=0.27.0"
+Combinatorics = "0.7, 1.0"
+Rmath = "0.5, 0.6"
+Roots = "0.7, 0.8"
+StatsBase = "0.27, 0.28, 0.29, 0.30, 0.31, 0.32"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"


### PR DESCRIPTION
Allow the oldest release of dependencies that works with Julia 1.0.

We will then enable CompatHelper.