### PR TITLE
Make alpha a keyword argument to confint

### DIFF
--- a/src/HypothesisTests.jl
+++ b/src/HypothesisTests.jl
@@ -91,9 +91,9 @@ pvalue(dist::DiscreteUnivariateDistribution, x::Number; tail=:both) =
         throw(ArgumentError("tail=$(tail) is invalid"))
     end
 
-function check_alpha(alpha::Float64)
-    if alpha <= 0 || alpha >= 0.5
-        throw(ArgumentError("alpha $alpha not in range (0, 0.5)"))
+function check_level(level::Float64)
+    if level >= 1 || level <= 0.5
+        throw(ArgumentError("coverage level $level not in range (0.5, 1)"))
     end
 end
 

--- a/src/HypothesisTests.jl
+++ b/src/HypothesisTests.jl
@@ -39,7 +39,7 @@ check_same_length(x::AbstractVector, y::AbstractVector) = if length(x) != length
 end
 
 """
-    confint(test::HypothesisTest, alpha = 0.05; tail = :both)
+    confint(test::HypothesisTest; alpha = 0.05, tail = :both)
 
 Compute a confidence interval C with coverage 1-`alpha`.
 

--- a/src/binomial.jl
+++ b/src/binomial.jl
@@ -68,7 +68,7 @@ pvalue(x::BinomialTest; tail=:both) = pvalue(Binomial(x.n, x.p), x.x; tail=tail)
 
 # Confidence interval
 """
-    confint(test::BinomialTest, alpha = 0.05; tail = :both, method = :clopper_pearson)
+    confint(test::BinomialTest; alpha = 0.05, tail = :both, method = :clopper_pearson)
 
 Compute a confidence interval with coverage 1-`alpha` for a binomial proportion using one
 of the following methods. Possible values for `method` are:
@@ -100,13 +100,13 @@ of the following methods. Possible values for `method` are:
   * [Binomial confidence interval on Wikipedia](https://en.wikipedia.org/wiki/
     Binomial_proportion_confidence_interval)
 """
-function StatsBase.confint(x::BinomialTest, alpha::Float64=0.05; tail=:both, method=:clopper_pearson)
+function StatsBase.confint(x::BinomialTest; alpha::Float64=0.05, tail=:both, method=:clopper_pearson)
     check_alpha(alpha)
 
     if tail == :left
-        (0.0, StatsBase.confint(x, alpha*2, method=method)[2])
+        (0.0, StatsBase.confint(x, alpha=alpha*2, method=method)[2])
     elseif tail == :right
-        (StatsBase.confint(x, alpha*2, method=method)[1], 1.0)
+        (StatsBase.confint(x, alpha=alpha*2, method=method)[1], 1.0)
     elseif tail == :both
         if method == :clopper_pearson
             ci_clopper_pearson(x, alpha)
@@ -214,7 +214,7 @@ end
 
 pvalue(x::SignTest; tail=:both) = pvalue(Binomial(x.n, 0.5), x.x; tail=tail)
 
-function StatsBase.confint(x::SignTest, alpha::Float64=0.05; tail=:both)
+function StatsBase.confint(x::SignTest; alpha::Float64=0.05, tail=:both)
     check_alpha(alpha)
 
     if tail == :left

--- a/src/binomial.jl
+++ b/src/binomial.jl
@@ -68,9 +68,9 @@ pvalue(x::BinomialTest; tail=:both) = pvalue(Binomial(x.n, x.p), x.x; tail=tail)
 
 # Confidence interval
 """
-    confint(test::BinomialTest; alpha = 0.05, tail = :both, method = :clopper_pearson)
+    confint(test::BinomialTest; level = 0.95, tail = :both, method = :clopper_pearson)
 
-Compute a confidence interval with coverage 1-`alpha` for a binomial proportion using one
+Compute a confidence interval with coverage `level` for a binomial proportion using one
 of the following methods. Possible values for `method` are:
 
   - `:clopper_pearson` (default): Clopper-Pearson interval is based on the binomial
@@ -100,26 +100,26 @@ of the following methods. Possible values for `method` are:
   * [Binomial confidence interval on Wikipedia](https://en.wikipedia.org/wiki/
     Binomial_proportion_confidence_interval)
 """
-function StatsBase.confint(x::BinomialTest; alpha::Float64=0.05, tail=:both, method=:clopper_pearson)
-    check_alpha(alpha)
+function StatsBase.confint(x::BinomialTest; level::Float64=0.95, tail=:both, method=:clopper_pearson)
+    check_level(level)
 
     if tail == :left
-        (0.0, StatsBase.confint(x, alpha=alpha*2, method=method)[2])
+        (0.0, StatsBase.confint(x, level=1-(1-level)*2, method=method)[2])
     elseif tail == :right
-        (StatsBase.confint(x, alpha=alpha*2, method=method)[1], 1.0)
+        (StatsBase.confint(x, level=1-(1-level)*2, method=method)[1], 1.0)
     elseif tail == :both
         if method == :clopper_pearson
-            ci_clopper_pearson(x, alpha)
+            ci_clopper_pearson(x, 1-level)
         elseif method == :wald
-            ci_wald(x, alpha)
+            ci_wald(x, 1-level)
         elseif method == :wilson
-            ci_wilson(x, alpha)
+            ci_wilson(x, 1-level)
         elseif method == :jeffrey
-            ci_jeffrey(x, alpha)
+            ci_jeffrey(x, 1-level)
         elseif method == :agresti_coull
-            ci_agresti_coull(x, alpha)
+            ci_agresti_coull(x, 1-level)
         elseif method == :arcsine
-            ci_arcsine(x, alpha)
+            ci_arcsine(x, 1-level)
         else
             throw(ArgumentError("method=$(method) is not implemented yet"))
         end
@@ -214,17 +214,17 @@ end
 
 pvalue(x::SignTest; tail=:both) = pvalue(Binomial(x.n, 0.5), x.x; tail=tail)
 
-function StatsBase.confint(x::SignTest; alpha::Float64=0.05, tail=:both)
-    check_alpha(alpha)
+function StatsBase.confint(x::SignTest; level::Float64=0.95, tail=:both)
+    check_level(level)
 
     if tail == :left
-        q = Int(quantile(Binomial(x.n, 0.5), alpha))
+        q = Int(quantile(Binomial(x.n, 0.5), 1-level))
         (x.data[q+1], x.median)
     elseif tail == :right
-        q = Int(quantile(Binomial(x.n, 0.5), alpha))
+        q = Int(quantile(Binomial(x.n, 0.5), 1-level))
         (x.median, x.data[end-q])
     elseif tail == :both
-        q = Int(quantile(Binomial(x.n, 0.5), alpha/2))
+        q = Int(quantile(Binomial(x.n, 0.5), (1-level)/2))
         (x.data[q+1], x.data[end-q])
     else
         throw(ArgumentError("tail=$(tail) is invalid"))

--- a/src/correlation.jl
+++ b/src/correlation.jl
@@ -57,9 +57,9 @@ end
 StatsBase.nobs(p::CorrelationTest) = p.n
 StatsBase.dof(p::CorrelationTest) = p.n - 2 - p.k
 
-function StatsBase.confint(test::CorrelationTest{T}, alpha::Float64=0.05) where T
+function StatsBase.confint(test::CorrelationTest{T}, level::Float64=0.95) where T
     dof(test) > 1 || return (-one(T), one(T))  # Otherwise we can get NaNs
-    q = quantile(Normal(), 1 - alpha / 2)
+    q = quantile(Normal(), 1 - (1-level) / 2)
     fisher = atanh(test.r)
     bound = q / sqrt(dof(test) - 1)
     elo = clampcor(tanh(fisher - bound))

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -9,4 +9,4 @@ using Base: @deprecate
 
 @deprecate BartlettsTest BartlettTest
 
-@deprecate confint(x::HypothesisTest, alpha::Real; kwargs...) confint(x; alpha=alpha, kwargs...)
+@deprecate confint(x::HypothesisTest, alpha::Real; kwargs...) confint(x; level=1-alpha, kwargs...)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -8,3 +8,5 @@ using Base: @deprecate
 @deprecate UnequalCovHotellingT2 UnequalCovHotellingT2Test
 
 @deprecate BartlettsTest BartlettTest
+
+@deprecate confint(x::HypothesisTest, alpha::Real; kwargs...) confint(x; alpha=alpha, kwargs...)

--- a/src/fisher.jl
+++ b/src/fisher.jl
@@ -159,9 +159,9 @@ end
 
 # confidence interval by inversion of p-value
 """
-    confint(x::FisherExactTest; alpha::Float64=0.05, tail=:both, method=:central)
+    confint(x::FisherExactTest; level::Float64=0.95, tail=:both, method=:central)
 
-Compute a confidence interval with coverage 1 - `alpha`. One-sided intervals are based on
+Compute a confidence interval with coverage `level`. One-sided intervals are based on
 Fisher's non-central hypergeometric distribution. For `tail = :both`, the only
 `method` implemented yet is the central interval (`:central`).
 
@@ -177,10 +177,10 @@ Fisher's non-central hypergeometric distribution. For `tail = :both`, the only
     Blaker’s exact tests". Biostatistics, Volume 11, Issue 2, 1 April 2010, Pages 373–374,
     [link](https://doi.org/10.1093/biostatistics/kxp050)
 """
-function StatsBase.confint(x::FisherExactTest; alpha::Float64=0.05, tail=:both, method=:central)
-    check_alpha(alpha)
+function StatsBase.confint(x::FisherExactTest; level::Float64=0.95, tail=:both, method=:central)
+    check_level(level)
     dist(ω) = FisherNoncentralHypergeometric(x.a+x.b, x.c+x.d, x.a+x.c, ω)
-    obj(ω) = pvalue(dist(ω), x.a, tail=tail) - alpha
+    obj(ω) = pvalue(dist(ω), x.a, tail=tail) - (1-level)
 
     if tail == :left # upper bound
         if (x.a == maximum(dist(1.0)))
@@ -196,8 +196,8 @@ function StatsBase.confint(x::FisherExactTest; alpha::Float64=0.05, tail=:both, 
         end
     elseif tail == :both
         if method == :central
-            (StatsBase.confint(x, alpha=alpha/2, tail=:right)[1],
-             StatsBase.confint(x, alpha=alpha/2, tail=:left)[2])
+            (StatsBase.confint(x, level=1-(1-level)/2, tail=:right)[1],
+             StatsBase.confint(x, level=1-(1-level)/2, tail=:left)[2])
         else
             throw(ArgumentError("method=$(method) is not implemented yet"))
         end

--- a/src/fisher.jl
+++ b/src/fisher.jl
@@ -159,7 +159,7 @@ end
 
 # confidence interval by inversion of p-value
 """
-    confint(x::FisherExactTest, alpha::Float64=0.05; tail=:both, method=:central)
+    confint(x::FisherExactTest; alpha::Float64=0.05, tail=:both, method=:central)
 
 Compute a confidence interval with coverage 1 - `alpha`. One-sided intervals are based on
 Fisher's non-central hypergeometric distribution. For `tail = :both`, the only
@@ -177,7 +177,7 @@ Fisher's non-central hypergeometric distribution. For `tail = :both`, the only
     Blaker’s exact tests". Biostatistics, Volume 11, Issue 2, 1 April 2010, Pages 373–374,
     [link](https://doi.org/10.1093/biostatistics/kxp050)
 """
-function StatsBase.confint(x::FisherExactTest, alpha::Float64=0.05; tail=:both, method=:central)
+function StatsBase.confint(x::FisherExactTest; alpha::Float64=0.05, tail=:both, method=:central)
     check_alpha(alpha)
     dist(ω) = FisherNoncentralHypergeometric(x.a+x.b, x.c+x.d, x.a+x.c, ω)
     obj(ω) = pvalue(dist(ω), x.a, tail=tail) - alpha
@@ -196,7 +196,8 @@ function StatsBase.confint(x::FisherExactTest, alpha::Float64=0.05; tail=:both, 
         end
     elseif tail == :both
         if method == :central
-            (StatsBase.confint(x, alpha/2; tail=:right)[1], StatsBase.confint(x, alpha/2; tail=:left)[2])
+            (StatsBase.confint(x, alpha=alpha/2, tail=:right)[1],
+             StatsBase.confint(x, alpha=alpha/2, tail=:left)[2])
         else
             throw(ArgumentError("method=$(method) is not implemented yet"))
         end

--- a/src/power_divergence.jl
+++ b/src/power_divergence.jl
@@ -44,7 +44,7 @@ default_tail(test::PowerDivergenceTest) = :right
 pvalue(x::PowerDivergenceTest; tail=:right) = pvalue(Chisq(x.df),x.stat; tail=tail)
 
 """
-    confint(test::PowerDivergenceTest, alpha = 0.05; tail = :both, method = :auto)
+    confint(test::PowerDivergenceTest; alpha = 0.05, tail = :both, method = :auto)
 
 Compute a confidence interval with coverage 1-`alpha` for multinomial proportions using
 one of the following methods. Possible values for `method` are:
@@ -67,7 +67,7 @@ one of the following methods. Possible values for `method` are:
   * Gold, R. Z. Tests Auxiliary to ``χ^2`` Tests in a Markov Chain. Annals of
     Mathematical Statistics, 30:56-74, 1963.
 """
-function StatsBase.confint(x::PowerDivergenceTest, alpha::Float64=0.05;
+function StatsBase.confint(x::PowerDivergenceTest; alpha::Float64=0.05,
                            tail::Symbol=:both, method::Symbol=:auto, correct::Bool=true,
                            bootstrap_iters::Int64=10000, GC::Bool=true)
     check_alpha(alpha)
@@ -75,10 +75,10 @@ function StatsBase.confint(x::PowerDivergenceTest, alpha::Float64=0.05;
     m  = length(x.thetahat)
 
     if tail == :left
-        i = StatsBase.confint(x, alpha*2,method=method, GC=GC)
+        i = StatsBase.confint(x, alpha=alpha*2, method=method, GC=GC)
         Tuple{Float64,Float64}[(0.0, i[j][2]) for j in 1:m]
     elseif tail == :right
-        i = StatsBase.confint(x, alpha*2,method=method, GC=GC)
+        i = StatsBase.confint(x, alpha=alpha*2, method=method, GC=GC)
         Tuple{Float64,Float64}[(i[j][1], 1.0) for j in 1:m]
     elseif tail == :both
         if method == :auto

--- a/src/power_divergence.jl
+++ b/src/power_divergence.jl
@@ -46,7 +46,7 @@ pvalue(x::PowerDivergenceTest; tail=:right) = pvalue(Chisq(x.df),x.stat; tail=ta
 """
     confint(test::PowerDivergenceTest; alpha = 0.05, tail = :both, method = :auto)
 
-Compute a confidence interval with coverage 1-`alpha` for multinomial proportions using
+Compute a confidence interval with coverage `level` for multinomial proportions using
 one of the following methods. Possible values for `method` are:
 
   - `:auto` (default): If the minimum of the expected cell counts exceeds 100, Quesenberry-Hurst
@@ -67,31 +67,31 @@ one of the following methods. Possible values for `method` are:
   * Gold, R. Z. Tests Auxiliary to ``χ^2`` Tests in a Markov Chain. Annals of
     Mathematical Statistics, 30:56-74, 1963.
 """
-function StatsBase.confint(x::PowerDivergenceTest; alpha::Float64=0.05,
+function StatsBase.confint(x::PowerDivergenceTest; level::Float64=0.95,
                            tail::Symbol=:both, method::Symbol=:auto, correct::Bool=true,
                            bootstrap_iters::Int64=10000, GC::Bool=true)
-    check_alpha(alpha)
+    check_level(level)
 
     m  = length(x.thetahat)
 
     if tail == :left
-        i = StatsBase.confint(x, alpha=alpha*2, method=method, GC=GC)
+        i = StatsBase.confint(x, level=1-(1-level)*2, method=method, GC=GC)
         Tuple{Float64,Float64}[(0.0, i[j][2]) for j in 1:m]
     elseif tail == :right
-        i = StatsBase.confint(x, alpha=alpha*2, method=method, GC=GC)
+        i = StatsBase.confint(x, level=1-(1-level)*2, method=method, GC=GC)
         Tuple{Float64,Float64}[(i[j][1], 1.0) for j in 1:m]
     elseif tail == :both
         if method == :auto
             method = minimum(x.expected) > 100 ? :quesenberry_hurst : :sison_glaz
         end
         if method == :gold
-            ci_gold(x,alpha,correct=correct,GC=GC)
+            ci_gold(x, 1-level, correct=correct, GC=GC)
         elseif method == :sison_glaz
-            ci_sison_glaz(x,alpha, skew_correct=correct)
+            ci_sison_glaz(x, 1-level, skew_correct=correct)
         elseif method == :quesenberry_hurst
-            ci_quesenberry_hurst(x,alpha,GC=GC)
+            ci_quesenberry_hurst(x, 1-level, GC=GC)
         elseif method == :bootstrap
-            ci_bootstrap(x,alpha,bootstrap_iters)
+            ci_bootstrap(x, 1-level, bootstrap_iters)
         else
             throw(ArgumentError("method=$(method) is invalid or not implemented yet"))
         end

--- a/src/t.jl
+++ b/src/t.jl
@@ -33,15 +33,15 @@ pvalue(x::TTest; tail=:both) = pvalue(TDist(x.df), x.t; tail=tail)
 default_tail(test::TTest) = :both
 
 # confidence interval by inversion
-function StatsBase.confint(x::TTest; alpha::Float64=0.05, tail=:both)
-    check_alpha(alpha)
+function StatsBase.confint(x::TTest; level::Float64=0.95, tail=:both)
+    check_level(level)
 
     if tail == :left
-        (-Inf, StatsBase.confint(x, alpha=alpha*2)[2])
+        (-Inf, StatsBase.confint(x, level=1-(1-level)*2)[2])
     elseif tail == :right
-        (StatsBase.confint(x, alpha=alpha*2)[1], Inf)
+        (StatsBase.confint(x, level=1-(1-level)*2)[1], Inf)
     elseif tail == :both
-        q = quantile(TDist(x.df), 1-alpha/2)
+        q = quantile(TDist(x.df), 1-(1-level)/2)
         (x.xbar-q*x.stderr, x.xbar+q*x.stderr)
     else
         throw(ArgumentError("tail=$(tail) is invalid"))

--- a/src/t.jl
+++ b/src/t.jl
@@ -33,13 +33,13 @@ pvalue(x::TTest; tail=:both) = pvalue(TDist(x.df), x.t; tail=tail)
 default_tail(test::TTest) = :both
 
 # confidence interval by inversion
-function StatsBase.confint(x::TTest, alpha::Float64=0.05; tail=:both)
+function StatsBase.confint(x::TTest; alpha::Float64=0.05, tail=:both)
     check_alpha(alpha)
 
     if tail == :left
-        (-Inf, StatsBase.confint(x, alpha*2)[2])
+        (-Inf, StatsBase.confint(x, alpha=alpha*2)[2])
     elseif tail == :right
-        (StatsBase.confint(x, alpha*2)[1], Inf)
+        (StatsBase.confint(x, alpha=alpha*2)[1], Inf)
     elseif tail == :both
         q = quantile(TDist(x.df), 1-alpha/2)
         (x.xbar-q*x.stderr, x.xbar+q*x.stderr)

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -161,7 +161,7 @@ function pvalue(x::ExactSignedRankTest; tail=:both)
     end
 end
 
-StatsBase.confint(x::ExactSignedRankTest; alpha::Real=0.05, tail=:both) = calculate_ci(x.vals, alpha, tail=tail)
+StatsBase.confint(x::ExactSignedRankTest; level::Real=0.95, tail=:both) = calculate_ci(x.vals, level, tail=tail)
 
 
 ## APPROXIMATE SIGNED RANK TEST
@@ -236,16 +236,16 @@ function pvalue(x::ApproximateSignedRankTest; tail=:both)
     end
 end
 
-StatsBase.confint(x::ApproximateSignedRankTest; alpha::Real=0.05, tail=:both) = calculate_ci(x.vals, alpha; tail=tail)
+StatsBase.confint(x::ApproximateSignedRankTest; level::Real=0.95, tail=:both) = calculate_ci(x.vals, level, tail=tail)
 
 # implementation method inspired by these notes: http://www.stat.umn.edu/geyer/old03/5102/notes/rank.pdf
-function calculate_ci(x::AbstractVector, alpha::Real=0.05; tail=:both)
-    check_alpha(alpha)
+function calculate_ci(x::AbstractVector, level::Real=0.95; tail=:both)
+    check_level(level)
 
     if tail == :both
-        c = 1 - alpha
+        c = level
     else
-        c = 1 - 2 * alpha
+        c = 1 - 2 * (1-level)
     end
     n = length(x)
     m = div(n * (n + 1), 2)

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -161,7 +161,7 @@ function pvalue(x::ExactSignedRankTest; tail=:both)
     end
 end
 
-StatsBase.confint(x::ExactSignedRankTest, alpha::Real=0.05; tail=:both) = calculate_ci(x.vals, alpha; tail=tail)
+StatsBase.confint(x::ExactSignedRankTest; alpha::Real=0.05, tail=:both) = calculate_ci(x.vals, alpha, tail=tail)
 
 
 ## APPROXIMATE SIGNED RANK TEST
@@ -236,7 +236,7 @@ function pvalue(x::ApproximateSignedRankTest; tail=:both)
     end
 end
 
-StatsBase.confint(x::ApproximateSignedRankTest, alpha::Real=0.05; tail=:both) = calculate_ci(x.vals, alpha; tail=tail)
+StatsBase.confint(x::ApproximateSignedRankTest; alpha::Real=0.05, tail=:both) = calculate_ci(x.vals, alpha; tail=tail)
 
 # implementation method inspired by these notes: http://www.stat.umn.edu/geyer/old03/5102/notes/rank.pdf
 function calculate_ci(x::AbstractVector, alpha::Real=0.05; tail=:both)

--- a/src/z.jl
+++ b/src/z.jl
@@ -33,15 +33,15 @@ pvalue(x::ZTest; tail=:both) = pvalue(Normal(0.0, 1.0), x.z; tail=tail)
 default_tail(test::ZTest) = :both
 
 # confidence interval by inversion
-function StatsBase.confint(x::ZTest; alpha::Float64=0.05, tail=:both)
-    check_alpha(alpha)
+function StatsBase.confint(x::ZTest; level::Float64=0.95, tail=:both)
+    check_level(level)
 
     if tail == :left
-        (-Inf, StatsBase.confint(x, alpha=alpha*2)[2])
+        (-Inf, StatsBase.confint(x, level=1-(1-level)*2)[2])
     elseif tail == :right
-        (StatsBase.confint(x, alpha=alpha*2)[1], Inf)
+        (StatsBase.confint(x, level=1-(1-level)*2)[1], Inf)
     elseif tail == :both
-        q = cquantile(Normal(0.0, 1.0), alpha/2)
+        q = cquantile(Normal(0.0, 1.0), (1-level)/2)
         (x.xbar-q*x.stderr, x.xbar+q*x.stderr)
     else
         throw(ArgumentError("tail=$(tail) is invalid"))

--- a/src/z.jl
+++ b/src/z.jl
@@ -33,13 +33,13 @@ pvalue(x::ZTest; tail=:both) = pvalue(Normal(0.0, 1.0), x.z; tail=tail)
 default_tail(test::ZTest) = :both
 
 # confidence interval by inversion
-function StatsBase.confint(x::ZTest, alpha::Float64=0.05; tail=:both)
+function StatsBase.confint(x::ZTest; alpha::Float64=0.05, tail=:both)
     check_alpha(alpha)
 
     if tail == :left
-        (-Inf, StatsBase.confint(x, alpha*2)[2])
+        (-Inf, StatsBase.confint(x, alpha=alpha*2)[2])
     elseif tail == :right
-        (StatsBase.confint(x, alpha*2)[1], Inf)
+        (StatsBase.confint(x, alpha=alpha*2)[1], Inf)
     elseif tail == :both
         q = cquantile(Normal(0.0, 1.0), alpha/2)
         (x.xbar-q*x.stderr, x.xbar+q*x.stderr)

--- a/test/binomial.jl
+++ b/test/binomial.jl
@@ -71,7 +71,7 @@ end
     @test pvalue(SignTest(x, 70), tail=:right) ≈ 0.9996356964111328
     @test default_tail(SignTest(x)) == :both
     @test_ci_approx confint(SignTest(x, 70)) (62, 69)
-    @test_ci_approx confint(SignTest(x, 70), alpha=0.0002) (61, 71)
+    @test_ci_approx confint(SignTest(x, 70), level=0.9998) (61, 71)
     show(IOBuffer(), SignTest(x, 70))
 
     x = [9, 2, 7, 5]
@@ -85,12 +85,12 @@ end
     @test pvalue(SignTest(x)) ≈ 0.03515625
     @test pvalue(SignTest(x), tail=:left) ≈ 0.996307373046875
     @test pvalue(SignTest(x), tail=:right) ≈ 0.017578125000000007
-    @test_ci_approx confint(SignTest(x), alpha=1-0.99995) (-7.8, 23.5)
-    @test_ci_approx confint(SignTest(x), alpha=1-0.9999) (-6.9, 22.4)
-    @test_ci_approx confint(SignTest(x), alpha=1-0.993) (-4.7, 20.2)
-    @test_ci_approx confint(SignTest(x), alpha=1-0.965) (3.7, 15.6)
-    @test_ci_approx confint(SignTest(x), alpha=1-0.882) (6.5, 14.4)
-    @test_ci_approx confint(SignTest(x), alpha=1-0.7) (8.7, 13.6)
-    @test_ci_approx confint(SignTest(x), alpha=1-0.6) (9.1, 10.8)
+    @test_ci_approx confint(SignTest(x), level=0.99995) (-7.8, 23.5)
+    @test_ci_approx confint(SignTest(x), level=0.9999) (-6.9, 22.4)
+    @test_ci_approx confint(SignTest(x), level=0.993) (-4.7, 20.2)
+    @test_ci_approx confint(SignTest(x), level=0.965) (3.7, 15.6)
+    @test_ci_approx confint(SignTest(x), level=0.882) (6.5, 14.4)
+    @test_ci_approx confint(SignTest(x), level=0.7) (8.7, 13.6)
+    @test_ci_approx confint(SignTest(x), level=0.6) (9.1, 10.8)
     show(IOBuffer(), SignTest(x))
 end

--- a/test/binomial.jl
+++ b/test/binomial.jl
@@ -71,7 +71,7 @@ end
     @test pvalue(SignTest(x, 70), tail=:right) ≈ 0.9996356964111328
     @test default_tail(SignTest(x)) == :both
     @test_ci_approx confint(SignTest(x, 70)) (62, 69)
-    @test_ci_approx confint(SignTest(x, 70), 0.0002) (61, 71)
+    @test_ci_approx confint(SignTest(x, 70), alpha=0.0002) (61, 71)
     show(IOBuffer(), SignTest(x, 70))
 
     x = [9, 2, 7, 5]
@@ -85,12 +85,12 @@ end
     @test pvalue(SignTest(x)) ≈ 0.03515625
     @test pvalue(SignTest(x), tail=:left) ≈ 0.996307373046875
     @test pvalue(SignTest(x), tail=:right) ≈ 0.017578125000000007
-    @test_ci_approx confint(SignTest(x), 1-0.99995) (-7.8, 23.5)
-    @test_ci_approx confint(SignTest(x), 1-0.9999) (-6.9, 22.4)
-    @test_ci_approx confint(SignTest(x), 1-0.993) (-4.7, 20.2)
-    @test_ci_approx confint(SignTest(x), 1-0.965) (3.7, 15.6)
-    @test_ci_approx confint(SignTest(x), 1-0.882) (6.5, 14.4)
-    @test_ci_approx confint(SignTest(x), 1-0.7) (8.7, 13.6)
-    @test_ci_approx confint(SignTest(x), 1-0.6) (9.1, 10.8)
+    @test_ci_approx confint(SignTest(x), alpha=1-0.99995) (-7.8, 23.5)
+    @test_ci_approx confint(SignTest(x), alpha=1-0.9999) (-6.9, 22.4)
+    @test_ci_approx confint(SignTest(x), alpha=1-0.993) (-4.7, 20.2)
+    @test_ci_approx confint(SignTest(x), alpha=1-0.965) (3.7, 15.6)
+    @test_ci_approx confint(SignTest(x), alpha=1-0.882) (6.5, 14.4)
+    @test_ci_approx confint(SignTest(x), alpha=1-0.7) (8.7, 13.6)
+    @test_ci_approx confint(SignTest(x), alpha=1-0.6) (9.1, 10.8)
     show(IOBuffer(), SignTest(x))
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -4,7 +4,7 @@ mutable struct TestTest <: HypothesisTests.HypothesisTest end
 
 @testset "Common" begin
 @test_throws DimensionMismatch HypothesisTests.check_same_length([1], [])
-@test_throws ArgumentError HypothesisTests.check_alpha(0.0)
+@test_throws ArgumentError HypothesisTests.check_level(1.0)
 
 result = HypothesisTests.population_param_of_interest(TestTest())
 @test result[1] == "not implemented yet"

--- a/test/t.jl
+++ b/test/t.jl
@@ -17,7 +17,7 @@ using HypothesisTests: default_tail
 	@test abs(pvalue(tst) - 0.0530) <= 1e-4
 
 	@test all(abs.([confint(tst)...;] - [-0.0369, 5.0369]) .<= 1e-4)
-	@test all(abs.([confint(tst, 0.1)...;] - [0.4135, 4.5865]) .<= 1e-4)
+	@test all(abs.([confint(tst, alpha=0.1)...;] - [0.4135, 4.5865]) .<= 1e-4)
 	c = confint(tst; tail=:left)
 	@test c[1] == -Inf
 	@test abs(c[2] - 4.5865) .<= 1e-4

--- a/test/t.jl
+++ b/test/t.jl
@@ -17,7 +17,7 @@ using HypothesisTests: default_tail
 	@test abs(pvalue(tst) - 0.0530) <= 1e-4
 
 	@test all(abs.([confint(tst)...;] - [-0.0369, 5.0369]) .<= 1e-4)
-	@test all(abs.([confint(tst, alpha=0.1)...;] - [0.4135, 4.5865]) .<= 1e-4)
+	@test all(abs.([confint(tst, level=0.9)...;] - [0.4135, 4.5865]) .<= 1e-4)
 	c = confint(tst; tail=:left)
 	@test c[1] == -Inf
 	@test abs(c[2] - 4.5865) .<= 1e-4

--- a/test/z.jl
+++ b/test/z.jl
@@ -27,8 +27,8 @@ null = Normal(0.0, 1.0)
 	@test pvalue(tst) ≈ 2 * min(cdf(null, z), ccdf(null, z))
 	@test confint(tst)[1] ≈ m + quantile(null, 0.05 / 2) * se
 	@test confint(tst)[2] ≈ m + cquantile(null, 0.05 / 2) * se
-	@test confint(tst, 0.10)[1] ≈ m + quantile(null, 0.10 / 2) * se
-	@test confint(tst, 0.10)[2] ≈ m + cquantile(null, 0.10 / 2) * se
+	@test confint(tst; alpha=0.10)[1] ≈ m + quantile(null, 0.10 / 2) * se
+	@test confint(tst; alpha=0.10)[2] ≈ m + cquantile(null, 0.10 / 2) * se
 	@test confint(tst; tail=:left)[1] ≈ -Inf
 	@test confint(tst; tail=:left)[2] ≈ m + cquantile(null, 0.05) * se
 	@test confint(tst; tail=:right)[1] ≈ m + quantile(null, 0.05) * se
@@ -50,8 +50,8 @@ null = Normal(0.0, 1.0)
 	@test pvalue(tst) ≈ 2 * min(cdf(null, z), ccdf(null, z))
 	@test confint(tst)[1] ≈ m + quantile(null, 0.05 / 2) * se
 	@test confint(tst)[2] ≈ m + cquantile(null, 0.05 / 2) * se
-	@test confint(tst, 0.10)[1] ≈ m + quantile(null, 0.10 / 2) * se
-	@test confint(tst, 0.10)[2] ≈ m + cquantile(null, 0.10 / 2) * se
+	@test confint(tst; alpha=0.10)[1] ≈ m + quantile(null, 0.10 / 2) * se
+	@test confint(tst; alpha=0.10)[2] ≈ m + cquantile(null, 0.10 / 2) * se
 	@test confint(tst; tail=:left)[1] ≈ -Inf
 	@test confint(tst; tail=:left)[2] ≈ m + cquantile(null, 0.05) * se
 	@test confint(tst; tail=:right)[1] ≈ m + quantile(null, 0.05) * se

--- a/test/z.jl
+++ b/test/z.jl
@@ -27,8 +27,8 @@ null = Normal(0.0, 1.0)
 	@test pvalue(tst) ≈ 2 * min(cdf(null, z), ccdf(null, z))
 	@test confint(tst)[1] ≈ m + quantile(null, 0.05 / 2) * se
 	@test confint(tst)[2] ≈ m + cquantile(null, 0.05 / 2) * se
-	@test confint(tst; alpha=0.10)[1] ≈ m + quantile(null, 0.10 / 2) * se
-	@test confint(tst; alpha=0.10)[2] ≈ m + cquantile(null, 0.10 / 2) * se
+	@test confint(tst; level=0.9)[1] ≈ m + quantile(null, 0.10 / 2) * se
+	@test confint(tst; level=0.9)[2] ≈ m + cquantile(null, 0.10 / 2) * se
 	@test confint(tst; tail=:left)[1] ≈ -Inf
 	@test confint(tst; tail=:left)[2] ≈ m + cquantile(null, 0.05) * se
 	@test confint(tst; tail=:right)[1] ≈ m + quantile(null, 0.05) * se
@@ -50,8 +50,8 @@ null = Normal(0.0, 1.0)
 	@test pvalue(tst) ≈ 2 * min(cdf(null, z), ccdf(null, z))
 	@test confint(tst)[1] ≈ m + quantile(null, 0.05 / 2) * se
 	@test confint(tst)[2] ≈ m + cquantile(null, 0.05 / 2) * se
-	@test confint(tst; alpha=0.10)[1] ≈ m + quantile(null, 0.10 / 2) * se
-	@test confint(tst; alpha=0.10)[2] ≈ m + cquantile(null, 0.10 / 2) * se
+	@test confint(tst; level=0.9)[1] ≈ m + quantile(null, 0.10 / 2) * se
+	@test confint(tst; level=0.9)[2] ≈ m + cquantile(null, 0.10 / 2) * se
 	@test confint(tst; tail=:left)[1] ≈ -Inf
 	@test confint(tst; tail=:left)[2] ≈ m + cquantile(null, 0.05) * se
 	@test confint(tst; tail=:right)[1] ≈ m + quantile(null, 0.05) * se


### PR DESCRIPTION
This is more consistent with StatsBase, which uses a `level` keyword argument for statistical models. In the future, we can add `level` to this package, and `alpha` to StatsBase.