### PR TITLE
Improve `ADFTest` documentation

### DIFF
--- a/src/augmented_dickey_fuller.jl
+++ b/src/augmented_dickey_fuller.jl
@@ -34,7 +34,7 @@ struct ADFTest <: HypothesisTest
 end
 
 """
-    ADFTest(y, deterministic, lag)
+    ADFTest(y::AbstractVector{T}, deterministic::Symbol, lag::Int) where T<:Real
 
 Compute the augmented Dickey-Fuller unit root test.
 

--- a/src/augmented_dickey_fuller.jl
+++ b/src/augmented_dickey_fuller.jl
@@ -39,7 +39,7 @@ end
 Compute the augmented Dickey-Fuller unit root test.
 
 `y` is the time series to be tested, `deterministic` determines the deterministic terms
-(options: `none`, `constant`, `trend`, `squared_trend`) and `lag` the number of lagged
+(options: `:none`, `:constant`, `:trend`, `:squared_trend`) and `lag` the number of lagged
 first-differences included in the test regression, respectively.
 
 Critical values and asymptotic p-values are computed based on response surface regressions


### PR DESCRIPTION
Alternative to #186, help with #185

If the signature is fully typed, its helpful to put them in the docs!
Also, state the options in docs with syntax that matches the types!