### PR TITLE
Faster Mann-Whitney

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -29,13 +29,16 @@
 # sum(n^3-n) where n is the number of ties for each data point
 function tiedrank_adj!(ord::AbstractVector, v::AbstractArray)
     n     = length(v)
+    (n == length(ord)) ||
+        throw(DimensionMismatch("The length of ord ($(length(ord))) differs from v length ($n)"))
     place = sortperm(v)
     tieadj = 0.0
 
     i = 1
-    while i <= n
+    @inbounds while i <= n
         j = i
-        while j + 1 <= n && v[place[i]] == v[place[j + 1]]
+        vi = v[place[i]]
+        while (j + 1 <= n) && (vi == v[place[j + 1]])
             j += 1
         end
 

--- a/src/mann_whitney.jl
+++ b/src/mann_whitney.jl
@@ -120,16 +120,12 @@ end
 function mwuenumerate(x::ExactMannWhitneyUTest)
     # Get the other U if inverted by mwu_stats
     n = min(x.nx, x.ny)
-    U = x.U
-    if x.ny > x.nx
-        U = x.nx*x.ny -x.U
-    end
+    U = (x.nx >= x.ny ? x.U : x.nx * x.ny - x.U) + n*(n + 1)/2
     le = 0
     gr = 0
     tot = 0
-    k = n*(n+1)/2
     for comb in combinations(x.ranks, n)
-        Up = sum(comb) - k
+        Up = sum(comb)
         tot += 1
         le += Up <= U
         gr += Up >= U

--- a/src/mann_whitney.jl
+++ b/src/mann_whitney.jl
@@ -62,10 +62,10 @@ function mwustats(x::AbstractVector{S}, y::AbstractVector{T}) where {S<:Real,T<:
     ny = length(y)
     if nx <= ny
         (ranks, tieadj) = tiedrank_adj([x; y])
-        U = sum(ranks[1:nx]) - nx*(nx+1)/2
+        U = sum(@view ranks[1:nx]) - nx*(nx+1)/2
     else
         (ranks, tieadj) = tiedrank_adj([y; x])
-        U = nx*ny - sum(ranks[1:ny]) + ny*(ny+1)/2
+        U = nx*ny - sum(@view ranks[1:ny]) + ny*(ny+1)/2
     end
     (U, ranks, tieadj, nx, ny, median(x)-median(y))
 end
@@ -110,7 +110,7 @@ function show_params(io::IO, x::ExactMannWhitneyUTest, ident)
     println(io)
     println(io, ident, "Mann-Whitney-U statistic:             ", x.U)
     print(io, ident, "rank sums:                            ")
-    show(io, [sum(x.ranks[1:x.nx]), sum(x.ranks[x.nx+1:end])])
+    show(io, [sum(@view x.ranks[1:x.nx]), sum(@view x.ranks[x.nx+1:end])])
     println(io)
     println(io, ident, "adjustment for ties:                  ", x.tie_adjustment)
 end


### PR DESCRIPTION
Some small optimizations to make Mann-Whitney faster:
* use views to avoid unnecessary array creation (it has a big impact, actually)
* use `@inbounds` in `tiderank_adj!()` (should help the other users of this method as well)
* tiny optimization in the math in `mwuenumerate()`