### PR TITLE
fix direction of comparison for two-tailed permutation test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HypothesisTests"
 uuid = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
-version = "0.9.2"
+version = "0.10.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/permutation.jl
+++ b/src/permutation.jl
@@ -42,7 +42,7 @@ end
 
 function pvalue(apt::PermutationTest; tail=:both)
     if tail == :both
-        count = sum(abs(apt.observation) >= abs(x) for x in apt.samples)
+        count = sum(abs(apt.observation) <= abs(x) for x in apt.samples)
     elseif tail == :left
         count = sum(apt.observation >= x for x in apt.samples)
     elseif tail == :right

--- a/test/permutation.jl
+++ b/test/permutation.jl
@@ -1,14 +1,14 @@
 using HypothesisTests, Test
 
 @testset "Permutation" begin
-@test isapprox(pvalue(ExactPermutationTest([1,2,3],[4,5,6],mean), tail=:both), 1.0)
-@test isapprox(pvalue(ExactPermutationTest([4,5,6],[1,2,3],mean), tail=:both), 1.0)
+@test isapprox(pvalue(ExactPermutationTest([1,2,3],[4,5,6],mean), tail=:both), 0.1)
+@test isapprox(pvalue(ExactPermutationTest([4,5,6],[1,2,3],mean), tail=:both), 0.1)
 @test isapprox(pvalue(ExactPermutationTest([1,2,3],[4,5,6],mean), tail=:left), 0.05)
 @test isapprox(pvalue(ExactPermutationTest([4,5,6],[1,2,3],mean), tail=:right), 0.05)
 
 Random.seed!(12345)
-@test isapprox(pvalue(ApproximatePermutationTest([1,2,3],[4,5,6],mean,100), tail=:both), 1.0)
-@test isapprox(pvalue(ApproximatePermutationTest([4,5,6],[1,2,3],mean,100), tail=:both), 1.0)
+@test isapprox(pvalue(ApproximatePermutationTest([1,2,3],[4,5,6],mean,100), tail=:both), 0.09)
+@test isapprox(pvalue(ApproximatePermutationTest([4,5,6],[1,2,3],mean,100), tail=:both), 0.04)
 @test isapprox(pvalue(ApproximatePermutationTest([1,2,3],[4,5,6],mean,100), tail=:left), 0.08)
 @test isapprox(pvalue(ApproximatePermutationTest([4,5,6],[1,2,3],mean,100), tail=:right), 0.07)
 end


### PR DESCRIPTION
Previously counted number of permuted test statistics LESS extreme than the
observed statistic.  this makes the both-tail behavior consisten with right/left
tail behavior by computing the fraction of permuted statistics that are as
or more extreme.  the tests have been updated to reflect that this makes the
two-tailed test more conservative (because ties count towards h0 under this
definition).

fixes #195

----

#