### PR TITLE
PermutationTest overhaul

### DIFF
--- a/docs/src/nonparametric.md
+++ b/docs/src/nonparametric.md
@@ -69,6 +69,6 @@ ApproximateSignedRankTest
 ## Permutation test
 
 ```@docs
-ExactPermutationTest
-ApproximatePermutationTest
+PermutationTest(::Function, ::AbstractVector, ::AbstractVector)
+PermutationTest(::Function, ::AbstractVector, ::AbstractVector, ::Integer)
 ```

--- a/docs/src/nonparametric.md
+++ b/docs/src/nonparametric.md
@@ -69,6 +69,5 @@ ApproximateSignedRankTest
 ## Permutation test
 
 ```@docs
-PermutationTest(::Function, ::AbstractVector, ::AbstractVector)
-PermutationTest(::Function, ::AbstractVector, ::AbstractVector, ::Integer)
+PermutationTest
 ```

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -10,3 +10,6 @@ using Base: @deprecate
 @deprecate BartlettsTest BartlettTest
 
 @deprecate confint(x::HypothesisTest, alpha::Real; kwargs...) confint(x; level=1-alpha, kwargs...)
+
+@deprecate ExactPermutationTest(x, y, f) PermutationTest(f, x, y)
+@deprecate ApproximatePermutationTest(x, y, f, n) PermutationTest(f, x, y, n)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -11,5 +11,8 @@ using Base: @deprecate
 
 @deprecate confint(x::HypothesisTest, alpha::Real; kwargs...) confint(x; level=1-alpha, kwargs...)
 
-@deprecate ExactPermutationTest(x, y, f) PermutationTest(f, x, y)
-@deprecate ApproximatePermutationTest(x, y, f, n) PermutationTest(f, x, y, n)
+@deprecate ExactPermutationTest(x::AbstractVector{<:Real}, y::AbstractVector{<:Real},
+    f::Function) PermutationTest(f, x, y)
+
+@deprecate ApproximatePermutationTest(x::AbstractVector{<:Real}, y::AbstractVector{<:Real},
+    f::Function, n::Integer) PermutationTest(f, x, y, n)

--- a/src/permutation.jl
+++ b/src/permutation.jl
@@ -3,8 +3,8 @@ export PermutationTest
 function ptstats(x,y)
     xy = vcat(x,y)
     rx = 1:length(x)
-    ry = (length(xy)-length(y)+1):length(xy)
-    (xy, rx, ry)
+    ry = (length(xy) - length(y) + 1):length(xy)
+    return (xy, rx, ry)
 end
 
 struct PermutationTest{T<:Real} <: HypothesisTest
@@ -47,22 +47,22 @@ function PermutationTest(
     PermutationTest(f(x) - f(y), samples)
 end
 
-function pvalue(apt::PermutationTest; tail=:both)
-    if tail == :both
-        count = sum(abs(apt.observation) <= abs(x) for x in apt.samples)
+function pvalue(pt::PermutationTest; tail=:both)
+    c = if tail == :both
+        count(abs(pt.observation) ≤ abs(x) for x in pt.samples)
     elseif tail == :left
-        count = sum(apt.observation >= x for x in apt.samples)
+        count(pt.observation ≥ x for x in pt.samples)
     elseif tail == :right
-        count = sum(apt.observation <= x for x in apt.samples)
+        count(pt.observation ≤ x for x in pt.samples)
     end
-    return count / length(apt.samples)
+    return c / length(pt.samples)
 end
 
 testname(::PermutationTest) = "Permutation Test"
 
-function show_params(io::IO, apt::PermutationTest, ident)
-    println(io, ident, "observation: ", apt.observation)
+function show_params(io::IO, pt::PermutationTest, ident)
+    println(io, ident, "observation: ", pt.observation)
     print(io, ident, "samples: ")
-    show(io, apt.samples)
+    show(io, pt.samples)
     println(io)
 end

--- a/src/permutation.jl
+++ b/src/permutation.jl
@@ -7,17 +7,20 @@ function ptstats(x,y)
     return (xy, rx, ry)
 end
 
+"""
+    PermutationTest(f, x::AbstractVector{<:Real}, y::AbstractVector{<:Real} [, n::Integer])
+
+Perform a permutation test (a.k.a. randomization test) of the null hypothesis
+that `f(x)` is equal to `f(y)`. If `n` is provided, an approximate permutation test is
+performed, where `n` of the `factorial(length(x) + length(y))` permutations are sampled at
+random. Otherwise, an exact permutation test is performed, where all possible permutations
+are sampled.
+"""
 struct PermutationTest{T<:Real} <: HypothesisTest
     observation::T
     samples::Vector{T}
 end
 
-"""
-    PermutationTest(f::Function, x::AbstractVector{<:Real}, y::AbstractVector{<:Real})
-
-Perform an exact permutation test (a.k.a. randomization test) of the null hypothesis
-that `f(x)` is equal to `f(y)`. All possible permutations are sampled.
-"""
 function PermutationTest(
     f::Function,
     x::AbstractVector{<:Real},
@@ -29,13 +32,6 @@ function PermutationTest(
     PermutationTest(f(x) - f(y), samples)
 end
 
-"""
-    PermutationTest(f::Function, x::AbstractVector{<:Real}, y::AbstractVector{<:Real}, n::Integer)
-
-Perform an approximate permutation test (a.k.a. randomization test) of the null hypothesis
-that `f(x)` is equal to `f(y)`. `n` of the `factorial(length(x) + length(y))`
-permutations are sampled at random.
-"""
 function PermutationTest(
     f::Function,
     x::AbstractVector{<:Real},

--- a/src/permutation.jl
+++ b/src/permutation.jl
@@ -1,4 +1,4 @@
-export ExactPermutationTest, ApproximatePermutationTest
+export PermutationTest
 
 function ptstats(x,y)
     xy = vcat(x,y)
@@ -13,30 +13,37 @@ struct PermutationTest{T<:Real} <: HypothesisTest
 end
 
 """
-    ExactPermutationTest(x::Vector, y::Vector, f::Function)
+    PermutationTest(f::Function, x::AbstractVector{<:Real}, y::AbstractVector{<:Real})
 
-Perform a permutation test (a.k.a. randomization test) of the null hypothesis
-that `f(x)` is equal to `f(y)`.  All possible permutations are sampled.
+Perform an exact permutation test (a.k.a. randomization test) of the null hypothesis
+that `f(x)` is equal to `f(y)`. All possible permutations are sampled.
 """
-function ExactPermutationTest(x::AbstractVector{R}, y::AbstractVector{S},
-                              f::Function) where {R<:Real,S<:Real}
-    xy, rx, ry = ptstats(x,y)
+function PermutationTest(
+    f::Function,
+    x::AbstractVector{<:Real},
+    y::AbstractVector{<:Real},
+)
+    xy, rx, ry = ptstats(x, y)
     P = permutations(xy)
-    samples = [f(view(p,rx)) - f(view(p,ry)) for p in P]
+    samples = [f(view(p, rx)) - f(view(p, ry)) for p in P]
     PermutationTest(f(x) - f(y), samples)
 end
 
 """
-    ApproximatePermutationTest(x::Vector, y::Vector, f::Function, n::Int)
+    PermutationTest(f::Function, x::AbstractVector{<:Real}, y::AbstractVector{<:Real}, n::Integer)
 
-Perform a permutation test (a.k.a. randomization test) of the null hypothesis
-that `f(x)` is equal to `f(y)`.  `n` of the `factorial(length(x)+length(y))`
+Perform an approximate permutation test (a.k.a. randomization test) of the null hypothesis
+that `f(x)` is equal to `f(y)`. `n` of the `factorial(length(x) + length(y))`
 permutations are sampled at random.
 """
-function ApproximatePermutationTest(x::AbstractVector{R}, y::AbstractVector{S},
-                                    f::Function, n::Int) where {R<:Real,S<:Real}
-    xy, rx, ry = ptstats(x,y)
-    samples = [(shuffle!(xy); f(view(xy,rx)) - f(view(xy,ry))) for i = 1:n]
+function PermutationTest(
+    f::Function,
+    x::AbstractVector{<:Real},
+    y::AbstractVector{<:Real},
+    n::Integer,
+)
+    xy, rx, ry = ptstats(x, y)
+    samples = [(shuffle!(xy); f(view(xy, rx)) - f(view(xy, ry))) for i = 1:n]
     PermutationTest(f(x) - f(y), samples)
 end
 

--- a/test/permutation.jl
+++ b/test/permutation.jl
@@ -1,14 +1,14 @@
-using HypothesisTests, Test
+using HypothesisTests, Test, Random, Statistics
 
 @testset "Permutation" begin
-@test isapprox(pvalue(ExactPermutationTest([1,2,3],[4,5,6],mean), tail=:both), 0.1)
-@test isapprox(pvalue(ExactPermutationTest([4,5,6],[1,2,3],mean), tail=:both), 0.1)
-@test isapprox(pvalue(ExactPermutationTest([1,2,3],[4,5,6],mean), tail=:left), 0.05)
-@test isapprox(pvalue(ExactPermutationTest([4,5,6],[1,2,3],mean), tail=:right), 0.05)
+@test isapprox(pvalue(PermutationTest(mean,[1,2,3],[4,5,6]), tail=:both), 0.1)
+@test isapprox(pvalue(PermutationTest(mean,[4,5,6],[1,2,3]), tail=:both), 0.1)
+@test isapprox(pvalue(PermutationTest(mean,[1,2,3],[4,5,6]), tail=:left), 0.05)
+@test isapprox(pvalue(PermutationTest(mean,[4,5,6],[1,2,3]), tail=:right), 0.05)
 
 Random.seed!(12345)
-@test isapprox(pvalue(ApproximatePermutationTest([1,2,3],[4,5,6],mean,100), tail=:both), 0.09)
-@test isapprox(pvalue(ApproximatePermutationTest([4,5,6],[1,2,3],mean,100), tail=:both), 0.04)
-@test isapprox(pvalue(ApproximatePermutationTest([1,2,3],[4,5,6],mean,100), tail=:left), 0.08)
-@test isapprox(pvalue(ApproximatePermutationTest([4,5,6],[1,2,3],mean,100), tail=:right), 0.07)
+@test isapprox(pvalue(PermutationTest(mean,[1,2,3],[4,5,6],100), tail=:both), 0.09)
+@test isapprox(pvalue(PermutationTest(mean,[4,5,6],[1,2,3],100), tail=:both), 0.04)
+@test isapprox(pvalue(PermutationTest(mean,[1,2,3],[4,5,6],100), tail=:left), 0.08)
+@test isapprox(pvalue(PermutationTest(mean,[4,5,6],[1,2,3],100), tail=:right), 0.07)
 end


### PR DESCRIPTION
This PR is an overhaul of the `PermutationTest` and

- Deprecates `ExactPermutationTest` and `ApproximatePermutationTest`
- Implements two constructors of `PermutationTest` for exact and approximate tests
- Changes the order of the constructor arguments, putting the function argument first, which allows the `do` block syntax to be used

Closes #207 