### PR TITLE
Correlation test

### DIFF
--- a/docs/src/multivariate.md
+++ b/docs/src/multivariate.md
@@ -17,7 +17,7 @@ This is equivalent to Box's ``M``-test for two groups.
 BartlettTest
 ```
 
-## Partial correlation test
+## Correlation and partial correlation test
 
 ```@docs
 CorrelationTest

--- a/src/correlation.jl
+++ b/src/correlation.jl
@@ -30,6 +30,14 @@ struct CorrelationTest{T<:Real} <: HypothesisTest
     k::Int
     t::T
 
+    # Error checking is done in `cor`
+    function CorrelationTest(x::AbstractVector, y::AbstractVector)
+        r = cor(x, y)
+        n = length(x)
+        t = r * sqrt((n - 2) / (1 - r^2))
+        return new{typeof(r)}(r, n, 0, t)
+    end
+
     # Error checking is done in `partialcor`
     function CorrelationTest(x::AbstractVector, y::AbstractVector, Z::AbstractMatrix)
         r = partialcor(x, y, Z)

--- a/src/correlation.jl
+++ b/src/correlation.jl
@@ -6,6 +6,11 @@ using Statistics: clampcor
 export CorrelationTest
 
 """
+    CorrelationTest(x, y)
+
+Perform a t-test for the hypothesis that ``\\text{Cor}(x,y) = 0``, i.e. the correlation 
+of vectors `x` and `y` is zero.
+
     CorrelationTest(x, y, Z)
 
 Perform a t-test for the hypothesis that ``\\text{Cor}(x,y|Z=z) = 0``, i.e. the partial

--- a/src/correlation.jl
+++ b/src/correlation.jl
@@ -60,10 +60,10 @@ struct CorrelationTest{T<:Real} <: HypothesisTest
 end
 
 testname(p::CorrelationTest) =
-    string("Test for nonzero ", p.k == 0 ? "partial " : "", " correlation")
+    string("Test for nonzero ", p.k != 0 ? "partial " : "", "correlation")
 
 function population_param_of_interest(p::CorrelationTest)
-    param = p.k == 0 ? "Partial correlation" : "Correlation"
+    param = p.k != 0 ? "Partial correlation" : "Correlation"
     (param, zero(p.r), p.r)
 end
 

--- a/test/correlation.jl
+++ b/test/correlation.jl
@@ -3,6 +3,30 @@ using Test
 using DelimitedFiles
 using StatsBase
 
+@testset "Correlation" begin
+    # Columns are line number, calcium, iron
+    nutrient = readdlm(joinpath(@__DIR__, "data", "nutrient.txt"))[:, 1:3]
+    w = CorrelationTest(nutrient[:,2], nutrient[:,3])
+    let out = sprint(show, w)
+        @test occursin("reject h_0", out) && !occursin("fail to", out)
+    end
+    let ci = confint(w)
+        @test first(ci) ≈ 0.3327138 atol=1e-6
+        @test last(ci) ≈ 0.4546639 atol=1e-6
+    end
+    @test nobs(w) == 737
+    @test dof(w) == 735
+    @test pvalue(w) < 1e-25
+
+    x = CorrelationTest(nutrient[:,1], nutrient[:,2])
+    @test occursin("fail to reject", sprint(show, x))
+    let ci = confint(x)
+        @test first(ci) ≈ -0.1105478 atol=1e-6
+        @test last(ci) ≈ 0.0336730 atol=1e-6
+    end
+    @test pvalue(x) ≈ 0.2948405 atol=1e-6
+end
+
 @testset "Partial correlation" begin
     # Columns are information, similarities, arithmetic, picture completion
     wechsler = readdlm(joinpath(@__DIR__, "data", "wechsler.txt"))[:,2:end]


### PR DESCRIPTION
This PR adds the correlation test for two vector inputs x and y. It
- adds an according constructor for the CorrelationTest struct
- extends the docstring and modifies the title in the documentation
- adds a test using the already present file nutrient.txt (I've made sure to get the same output as cor.test in R)
- fixes the naming of the test (we test for partial correlation instead of correlation if k !=0, it was the other way around)