### PR TITLE
Stop testing on 32 bit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,6 @@ jobs:
           - windows-latest
         arch:
           - x64
-          - x86
-        exclude:
-          - os: macOS-latest
-            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
It's failing and it's not worth our time to fix it. If somebody would like to fix 32 bit then they can reenable it later in a PR.