### PR TITLE
Fix machine error negative values on m2

### DIFF
--- a/src/jarque_bera.jl
+++ b/src/jarque_bera.jl
@@ -63,7 +63,7 @@ function JarqueBeraTest(y::AbstractVector{T}) where T<:Real
         m4r += yi^4 / n
     end
     # compute central moments (http://mathworld.wolfram.com/CentralMoment.html)
-    m2 = -m1r^2 + m2r
+    m2 = abs(-m1r^2 + m2r)
     m3 = 2 * m1r^3 - 3 * m1r * m2r + m3r
     m4 = -3 * m1r^4 + 6 * m1r^2 * m2r - 4 * m1r * m3r + m4r
 


### PR DESCRIPTION
I found an issue with this test when m2 takes negative values due to machine error precision, see below:

x = [0.09999999999999981, 0.09999999999999978, 0.09999999999999978, 0.09999999999999978, 0.09999999999999977, 0.09999999999999983, 0.09999999999999981, 0.0999999999999998, 0.09999999999999981, 0.09999999999999978];

JarqueBeraTest(x)
ERROR: DomainError with -1.734723475976807e-18:
Exponentiation yielding a complex result requires a complex argument.
Replace x^y with (x+0im)^y, Complex(x)^y, or similar.