### PR TITLE
Mention other names for OneSampleTTest

### DIFF
--- a/src/t.jl
+++ b/src/t.jl
@@ -107,7 +107,7 @@ alternative hypothesis that the distribution does not have mean `μ0`.
 Implements: [`pvalue`](@ref), [`confint`](@ref)
     
 !!! note
-    This test is also known as a dependent samples t-test, dependent means t-test or correlated pairs t-test.
+    This test is also known as a t-test for paired or dependent samples,  see [paired difference test](https://en.wikipedia.org/wiki/Paired_difference_test) on Wikipedia.
 """
 function OneSampleTTest(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0) where {T<:Real, S<:Real}
     check_same_length(x, y)

--- a/src/t.jl
+++ b/src/t.jl
@@ -107,7 +107,7 @@ alternative hypothesis that the distribution does not have mean `μ0`.
 Implements: [`pvalue`](@ref), [`confint`](@ref)
     
 !!! note
-    This test is also known as a t-test for paired or dependent samples,  see [paired difference test](https://en.wikipedia.org/wiki/Paired_difference_test) on Wikipedia.
+    This test is also known as a t-test for paired or dependent samples, see [paired difference test](https://en.wikipedia.org/wiki/Paired_difference_test) on Wikipedia.
 """
 function OneSampleTTest(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0) where {T<:Real, S<:Real}
     check_same_length(x, y)

--- a/src/t.jl
+++ b/src/t.jl
@@ -107,7 +107,8 @@ alternative hypothesis that the distribution does not have mean `μ0`.
 Implements: [`pvalue`](@ref), [`confint`](@ref)
     
 !!! note
-    This test is also known as a t-test for paired or dependent samples, see [paired difference test](https://en.wikipedia.org/wiki/Paired_difference_test) on Wikipedia.
+    This test is also known as a t-test for paired or dependent samples, see
+    [paired difference test](https://en.wikipedia.org/wiki/Paired_difference_test) on Wikipedia.
 """
 function OneSampleTTest(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0) where {T<:Real, S<:Real}
     check_same_length(x, y)

--- a/src/t.jl
+++ b/src/t.jl
@@ -105,6 +105,9 @@ values in vectors `x` and `y` come from a distribution with mean `μ0` against t
 alternative hypothesis that the distribution does not have mean `μ0`.
 
 Implements: [`pvalue`](@ref), [`confint`](@ref)
+    
+!!! note
+    This test is also known as a dependent samples t-test, dependent means t-test or correlated pairs t-test.
 """
 function OneSampleTTest(x::AbstractVector{T}, y::AbstractVector{S}, μ0::Real=0) where {T<:Real, S<:Real}
     check_same_length(x, y)


### PR DESCRIPTION
Closes #246

@mschauer, given your comments in the linked issue, I've been thinking about a compromise. Maybe we can add a note listing some alternative names to indicate to readers that the name `OneSampleTTest` is also just a name and shouldn't be taken too literally.