### PR TITLE
Fix incorrect bracket and type instability in FisherExactTest

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HypothesisTests"
 uuid = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
-version = "0.10.4"
+version = "0.10.5"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/fisher.jl
+++ b/src/fisher.jl
@@ -186,13 +186,15 @@ function StatsBase.confint(x::FisherExactTest; level::Float64=0.95, tail=:both, 
         if (x.a == maximum(dist(1.0)))
             (0.0, Inf)
         else
-            (0.0, fzero(obj, find_brackets(obj)...))
+            lower, upper = find_brackets(obj)
+            (0.0, lower == upper ? lower : find_zero(obj, (lower, upper)))
         end
     elseif tail == :right # lower bound
         if (x.a == minimum(dist(1.0)))
             (0.0, Inf)
         else
-            (fzero(obj, find_brackets(obj)...), Inf)
+            lower, upper = find_brackets(obj)
+            (lower == upper ? lower : find_zero(obj, (lower, upper)), Inf)
         end
     elseif tail == :both
         if method == :central
@@ -251,6 +253,7 @@ function cond_mle_odds_ratio(a::Int, b::Int, c::Int, d::Int)
         Inf
     else
         obj(ω) = mean(dist(ω))-a
-        fzero(obj, find_brackets(obj)...)
+        lower, upper = find_brackets(obj)
+        lower == upper ? lower : find_zero(obj, (lower, upper))
     end
 end

--- a/test/fisher.jl
+++ b/test/fisher.jl
@@ -2,7 +2,7 @@ using HypothesisTests, Test
 using HypothesisTests: default_tail
 
 @testset "Fisher" begin
-t = HypothesisTests.FisherExactTest(1, 1, 1, 1)
+t = @inferred(HypothesisTests.FisherExactTest(1, 1, 1, 1))
 @test t.ω ≈ 1.0
 @test pvalue(t; tail=:left) ≈ 0.8333333333333337
 @test pvalue(t; tail=:right) ≈ 0.8333333333333337


### PR DESCRIPTION
Fixes https://github.com/JuliaStats/HypothesisTests.jl/issues/245 by checking if the tuple returned by `find_brackets` is a proper bracket. Moreover, I replaced `fzero` with `find_zero` since in contrast to the former the latter seems to be type stable.