### PR TITLE
Round confidence interval in `show` to 4 significant digits

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HypothesisTests"
 uuid = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
-version = "0.10.5"
+version = "0.10.6"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HypothesisTests"
 uuid = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
-version = "0.10.4"
+version = "0.10.5"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/HypothesisTests.jl
+++ b/src/HypothesisTests.jl
@@ -116,7 +116,7 @@ function Base.show(_io::IO, test::T) where T<:HypothesisTest
     println(io)
 
     if has_ci
-        ci = map(x -> round.(x, digits=4, base=10), StatsBase.confint(test))
+        ci = map(x -> round.(x; sigdigits=4, base=10), StatsBase.confint(test))
         print(io, "    95% confidence interval: ")
         show(io, ci)
         println(io)

--- a/src/fisher.jl
+++ b/src/fisher.jl
@@ -186,13 +186,15 @@ function StatsBase.confint(x::FisherExactTest; level::Float64=0.95, tail=:both, 
         if (x.a == maximum(dist(1.0)))
             (0.0, Inf)
         else
-            (0.0, fzero(obj, find_brackets(obj)...))
+            lower, upper = find_brackets(obj)
+            (0.0, lower == upper ? lower : find_zero(obj, (lower, upper)))
         end
     elseif tail == :right # lower bound
         if (x.a == minimum(dist(1.0)))
             (0.0, Inf)
         else
-            (fzero(obj, find_brackets(obj)...), Inf)
+            lower, upper = find_brackets(obj)
+            (lower == upper ? lower : find_zero(obj, (lower, upper)), Inf)
         end
     elseif tail == :both
         if method == :central
@@ -251,6 +253,7 @@ function cond_mle_odds_ratio(a::Int, b::Int, c::Int, d::Int)
         Inf
     else
         obj(ω) = mean(dist(ω))-a
-        fzero(obj, find_brackets(obj)...)
+        lower, upper = find_brackets(obj)
+        lower == upper ? lower : find_zero(obj, (lower, upper))
     end
 end

--- a/test/fisher.jl
+++ b/test/fisher.jl
@@ -2,7 +2,7 @@ using HypothesisTests, Test
 using HypothesisTests: default_tail
 
 @testset "Fisher" begin
-t = HypothesisTests.FisherExactTest(1, 1, 1, 1)
+t = @inferred(HypothesisTests.FisherExactTest(1, 1, 1, 1))
 @test t.ω ≈ 1.0
 @test pvalue(t; tail=:left) ≈ 0.8333333333333337
 @test pvalue(t; tail=:right) ≈ 0.8333333333333337

--- a/test/show.jl
+++ b/test/show.jl
@@ -14,7 +14,7 @@ if VERSION < v"1.4"
         parameter of interest:   Multinomial Probabilities
         value under h_0:         [0.255231, 0.19671, 0.11594, 0.0893561, 0.193574, 0.14919]
         point estimate:          [0.276387, 0.175553, 0.118607, 0.0866884, 0.16975, 0.173014]
-        95% confidence interval: Tuple{Float64,Float64}[(0.2545, 0.2994), (0.1573, 0.1955), (0.1033, 0.1358), (0.0736, 0.1019), (0.1517, 0.1894), (0.1548, 0.1928)]
+        95% confidence interval: Tuple{Float64,Float64}[(0.2545, 0.2994), (0.1573, 0.1955), (0.1033, 0.1358), (0.07357, 0.1019), (0.1517, 0.1894), (0.1548, 0.1928)]
 
     Test summary:
         outcome with 95% confidence: reject h_0
@@ -61,7 +61,7 @@ elseif VERSION < v"1.6"
         parameter of interest:   Multinomial Probabilities
         value under h_0:         [0.255231, 0.19671, 0.11594, 0.0893561, 0.193574, 0.14919]
         point estimate:          [0.276387, 0.175553, 0.118607, 0.0866884, 0.16975, 0.173014]
-        95% confidence interval: [(0.2545, 0.2994), (0.1573, 0.1955), (0.1033, 0.1358), (0.0736, 0.1019), (0.1517, 0.1894), (0.1548, 0.1928)]
+        95% confidence interval: [(0.2545, 0.2994), (0.1573, 0.1955), (0.1033, 0.1358), (0.07357, 0.1019), (0.1517, 0.1894), (0.1548, 0.1928)]
 
     Test summary:
         outcome with 95% confidence: reject h_0
@@ -108,7 +108,7 @@ else
             parameter of interest:   Multinomial Probabilities
             value under h_0:         [0.255231, 0.19671, 0.11594, 0.0893561, 0.193574, 0.14919]
             point estimate:          [0.276387, 0.175553, 0.118607, 0.0866884, 0.16975, 0.173014]
-            95% confidence interval: [(0.2545, 0.2994), (0.1573, 0.1955), (0.1033, 0.1358), (0.0736, 0.1019), (0.1517, 0.1894), (0.1548, 0.1928)]
+            95% confidence interval: [(0.2545, 0.2994), (0.1573, 0.1955), (0.1033, 0.1358), (0.07357, 0.1019), (0.1517, 0.1894), (0.1548, 0.1928)]
 
         Test summary:
             outcome with 95% confidence: reject h_0
@@ -159,7 +159,7 @@ tst = OneSampleTTest(-5:10)
         parameter of interest:   Mean
         value under h_0:         0
         point estimate:          2.5
-        95% confidence interval: (-0.0369, 5.0369)
+        95% confidence interval: (-0.03693, 5.037)
 
     Test summary:
         outcome with 95% confidence: fail to reject h_0
@@ -172,4 +172,65 @@ tst = OneSampleTTest(-5:10)
         empirical standard error: 1.1902380714238083
     """
 
+# issue #248
+x = [
+    6.598170000000001e-7,
+    6.9452e-7,
+    2.41933e-7,
+    2.4264999999999997e-7,
+    4.830650000000001e-7,
+    2.67262e-7,
+    2.5027699999999996e-7,
+    2.51241e-7,
+    2.67511e-7,
+    2.27148e-7,
+    2.41169e-7,
+    2.56646e-7,
+    4.31067e-7,
+    2.2686500000000001e-7,
+    2.35553e-7,
+    2.32062e-7,
+    7.36284e-7,
+]
+y = [
+    3.59147e-7,
+    2.75594e-7,
+    1.63942e-7,
+    1.7980399999999999e-7,
+    2.82113e-7,
+    1.6574299999999998e-7,
+    1.60492e-7,
+    1.61266e-7,
+    2.12196e-7,
+    1.51524e-7,
+    1.86578e-7,
+    2.1346e-7,
+    1.59902e-7,
+    1.50073e-7,
+    1.64e-7,
+    1.42769e-7,
+    1.70032e-7,
+]
+tst = UnequalVarianceTTest(x, y)
+
+@test sprint(show, tst) ==
+    """
+    Two sample t-test (unequal variance)
+    ------------------------------------
+    Population details:
+        parameter of interest:   Mean difference
+        value under h_0:         0
+        point estimate:          1.55673e-7
+        95% confidence interval: (5.93e-8, 2.52e-7)
+
+    Test summary:
+        outcome with 95% confidence: reject h_0
+        two-sided p-value:           0.0031
+
+    Details:
+        number of observations:   [17,17]
+        t-statistic:              3.3767280623082523
+        degrees of freedom:       19.363987783845342
+        empirical standard error: 4.610162387563106e-8
+    """
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaStats/HypothesisTests.jl/issues/248 by rounding to 4 significant digits instead of 4 digits in `show`.

With this PR the example in #248 yields:
```julia
julia> tst = UnequalVarianceTTest(x, y)
Two sample t-test (unequal variance)
------------------------------------
Population details:
    parameter of interest:   Mean difference
    value under h_0:         0
    point estimate:          1.55673e-7
    95% confidence interval: (5.93e-8, 2.52e-7)

Test summary:
    outcome with 95% confidence: reject h_0
    two-sided p-value:           0.0031

Details:
    number of observations:   [17,17]
    t-statistic:              3.3767280623082523
    degrees of freedom:       19.363987783845342
    empirical standard error: 4.610162387563106e-8
```
i.e. the CI is not displayed as `(0.0, 0.0)` but as `(5.93e-8, 2.52e-7)`.

The PR is based on https://github.com/JuliaStats/HypothesisTests.jl/pull/249 since otherwise tests fail due to the issue with `find_brackets`.