### PR TITLE
Use StableRNG in more tests to avoid breakage in Julia 1.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.3'
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Distributions = "0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
 Rmath = "0.5, 0.6, 0.7"
 Roots = "0.7, 0.8, 1.0"
 StatsBase = "0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
-julia = "1"
+julia = "1.3"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/src/permutation.jl
+++ b/src/permutation.jl
@@ -18,8 +18,11 @@ end
 Perform a permutation test (a.k.a. randomization test) of the null hypothesis
 that `f(x)` is equal to `f(y)`.  All possible permutations are sampled.
 """
-function ExactPermutationTest(x::AbstractVector{R}, y::AbstractVector{S},
-                              f::Function) where {R<:Real,S<:Real}
+function ExactPermutationTest(
+    x::AbstractVector{R},
+    y::AbstractVector{S},
+    f::Function
+) where {R<:Real,S<:Real}
     xy, rx, ry = ptstats(x,y)
     P = permutations(xy)
     samples = [f(view(p,rx)) - f(view(p,ry)) for p in P]
@@ -27,18 +30,30 @@ function ExactPermutationTest(x::AbstractVector{R}, y::AbstractVector{S},
 end
 
 """
-    ApproximatePermutationTest(x::Vector, y::Vector, f::Function, n::Int)
+    ApproximatePermutationTest([rng::AbstractRNG,] x::Vector, y::Vector, f::Function, n::Int)
 
 Perform a permutation test (a.k.a. randomization test) of the null hypothesis
 that `f(x)` is equal to `f(y)`.  `n` of the `factorial(length(x)+length(y))`
-permutations are sampled at random.
+permutations are sampled at random. A random number generator can optionally
+be passed as the first argument. The default generator is `Random.default_rng()`.
 """
-function ApproximatePermutationTest(x::AbstractVector{R}, y::AbstractVector{S},
-                                    f::Function, n::Int) where {R<:Real,S<:Real}
+function ApproximatePermutationTest(
+    rng::AbstractRNG,
+    x::AbstractVector{R},
+    y::AbstractVector{S},
+    f::Function,
+    n::Int
+) where {R<:Real,S<:Real}
     xy, rx, ry = ptstats(x,y)
-    samples = [(shuffle!(xy); f(view(xy,rx)) - f(view(xy,ry))) for i = 1:n]
+    samples = [(shuffle!(rng, xy); f(view(xy,rx)) - f(view(xy,ry))) for i = 1:n]
     PermutationTest(f(x) - f(y), samples)
 end
+ApproximatePermutationTest(
+    x::AbstractVector{R},
+    y::AbstractVector{S},
+    f::Function,
+    n::Int
+) where {R<:Real,S<:Real} = ApproximatePermutationTest(Random.default_rng(), x, y, f, n)
 
 function pvalue(apt::PermutationTest; tail=:both)
     if tail == :both

--- a/src/permutation.jl
+++ b/src/permutation.jl
@@ -18,11 +18,8 @@ end
 Perform a permutation test (a.k.a. randomization test) of the null hypothesis
 that `f(x)` is equal to `f(y)`.  All possible permutations are sampled.
 """
-function ExactPermutationTest(
-    x::AbstractVector{R},
-    y::AbstractVector{S},
-    f::Function
-) where {R<:Real,S<:Real}
+function ExactPermutationTest(x::AbstractVector{R}, y::AbstractVector{S},
+                              f::Function) where {R<:Real,S<:Real}
     xy, rx, ry = ptstats(x,y)
     P = permutations(xy)
     samples = [f(view(p,rx)) - f(view(p,ry)) for p in P]
@@ -37,23 +34,15 @@ that `f(x)` is equal to `f(y)`.  `n` of the `factorial(length(x)+length(y))`
 permutations are sampled at random. A random number generator can optionally
 be passed as the first argument. The default generator is `Random.default_rng()`.
 """
-function ApproximatePermutationTest(
-    rng::AbstractRNG,
-    x::AbstractVector{R},
-    y::AbstractVector{S},
-    f::Function,
-    n::Int
-) where {R<:Real,S<:Real}
+function ApproximatePermutationTest(rng::AbstractRNG, x::AbstractVector{R}, y::AbstractVector{S},
+                                    f::Function, n::Int) where {R<:Real,S<:Real}
     xy, rx, ry = ptstats(x,y)
     samples = [(shuffle!(rng, xy); f(view(xy,rx)) - f(view(xy,ry))) for i = 1:n]
     PermutationTest(f(x) - f(y), samples)
 end
-ApproximatePermutationTest(
-    x::AbstractVector{R},
-    y::AbstractVector{S},
-    f::Function,
-    n::Int
-) where {R<:Real,S<:Real} = ApproximatePermutationTest(Random.default_rng(), x, y, f, n)
+ApproximatePermutationTest(x::AbstractVector{R}, y::AbstractVector{S},
+                           f::Function, n::Int) where {R<:Real,S<:Real} =
+    ApproximatePermutationTest(Random.default_rng(), x, y, f, n)
 
 function pvalue(apt::PermutationTest; tail=:both)
     if tail == :both

--- a/test/anderson_darling.jl
+++ b/test/anderson_darling.jl
@@ -1,57 +1,57 @@
 using HypothesisTests, Distributions, Test, Random
 using HypothesisTests: default_tail
+using StableRNGs
 
 @testset "Anderson-Darling" begin
 @testset "One sample test" begin
     n = 1000
-    Random.seed!(1984948)
+    rng = StableRNG(1984948)
 
     d = Normal(1000, 100)
-    x = rand(d, n)
+    x = rand(rng, d, n)
     t = OneSampleADTest(x, d)
-    @test t.A² ≈ 0.3078 atol=0.1^4
-    @test pvalue(t) ≈ 0.9321 atol=0.1^4
+    @test t.A² ≈ 1.2960 atol=0.1^4
+    @test pvalue(t) ≈ 0.2336 atol=0.1^4
     @test default_tail(t) == :right
 
     d = DoubleExponential()
-    x = rand(d, n)
+    x = rand(rng, d, n)
     t = OneSampleADTest(x, Normal(mean(d), std(d)))
-    @test t.A² ≈ 11.3969 atol=0.1^4
+    @test t.A² ≈ 11.0704 atol=0.1^4
     @test pvalue(t) ≈ 0.0 atol=0.1^4
     t = OneSampleADTest(x, d)
-    @test t.A² ≈ 0.6036 atol=0.1^4
-    @test pvalue(t) ≈ 0.6446 atol=0.1^4
+    @test t.A² ≈ 0.8968 atol=0.1^4
+    @test pvalue(t) ≈ 0.4162 atol=0.1^4
 
     d = Cauchy()
-    x = rand(Cauchy(), n)
+    x = rand(rng, Cauchy(), n)
     t = OneSampleADTest(x, Normal())
     @test pvalue(t) ≈ 0.0 atol=0.1^4
     t = OneSampleADTest(x, d)
-    @test pvalue(t) ≈ 0.6773 atol=0.1^4
+    @test pvalue(t) ≈ 0.9640 atol=0.1^4
 
     d = LogNormal()
-    x = rand(d, n)
+    x = rand(rng, d, n)
     t = OneSampleADTest(x, Normal(mean(d), std(d)))
     @test pvalue(t) ≈ 0.0 atol=0.1^4
     t = OneSampleADTest(x, d)
-    @test pvalue(t) ≈ 0.1055 atol=0.1^4
+    @test pvalue(t) ≈ 0.9123 atol=0.1^4
 
     d = Uniform(-pi, 2pi)
-    x = rand(d, n)
+    x = rand(rng, d, n)
     t = OneSampleADTest(x, d)
-    @test pvalue(t) ≈ 0.5614 atol=0.1^4
+    @test pvalue(t) ≈ 0.2337 atol=0.1^4
 
-    x = rand(Uniform(0, 1.8), n)
+    x = rand(rng, Uniform(0, 1.8), n)
     t = OneSampleADTest(x, Uniform())
     @test pvalue(t) ≈ 0.0 atol=0.1^4
 
-    x = rand(Exponential(), n)
+    x = rand(rng, Exponential(), n)
     t = OneSampleADTest(x, Exponential())
-    @test pvalue(t) ≈ 0.1086 atol=0.1^4
+    @test pvalue(t) ≈ 0.8579 atol=0.1^4
 end
 
 @testset "k-sample test" begin
-    Random.seed!(948574875)
     samples = Any[
         [38.7, 41.5, 43.8, 44.5, 45.5, 46.0, 47.7, 58.0],
         [39.2, 39.3, 39.7, 41.4, 41.8, 42.9, 43.3, 45.8],
@@ -78,20 +78,20 @@ end
 end
 
 @testset "more tests" begin
-    Random.seed!(31412455)
-    samples = Any[rand(Normal(), 50), rand(Normal(0.5), 30)]
+    rng =  StableRNG(31412455)
+    samples = Any[rand(rng, Normal(), 50), rand(rng, Normal(0.5), 30)]
     t = KSampleADTest(samples...)
     @test pvalue(t) < 0.05
 
-    samples = Any[rand(Normal(), 50), rand(Normal(), 30), rand(Normal(), 20)]
+    samples = Any[rand(rng, Normal(), 50), rand(rng, Normal(), 30), rand(rng, Normal(), 20)]
     t = KSampleADTest(samples...)
     @test pvalue(t) > 0.05
 
-    @test pvalue(OneSampleADTest(vcat(rand(Normal(),500), rand(Beta(2,2),500)), Beta(2,2))) ≈ 0.0 atol=0.1^4
+    @test pvalue(OneSampleADTest(vcat(rand(rng, Normal(),500), rand(rng, Beta(2,2),500)), Beta(2,2))) ≈ 0.0 atol=0.1^4
 
     n = 1000
-    x = rand(Exponential(), n)
-    @test pvalue(KSampleADTest(rand(1000),randn(1000))) ≈ 0.0 atol=eps()
+    x = rand(rng, Exponential(), n)
+    @test pvalue(KSampleADTest(rand(rng, 1000), randn(rng, 1000))) ≈ 0.0 atol=eps()
     @test pvalue(KSampleADTest(x,x,x,x,x,x)) ≈ 1.0
 end
 

--- a/test/permutation.jl
+++ b/test/permutation.jl
@@ -1,14 +1,20 @@
-using HypothesisTests, Test
+using HypothesisTests, Test, Statistics, StableRNGs
 
 @testset "Permutation" begin
-@test isapprox(pvalue(ExactPermutationTest([1,2,3],[4,5,6],mean), tail=:both), 0.1)
-@test isapprox(pvalue(ExactPermutationTest([4,5,6],[1,2,3],mean), tail=:both), 0.1)
-@test isapprox(pvalue(ExactPermutationTest([1,2,3],[4,5,6],mean), tail=:left), 0.05)
-@test isapprox(pvalue(ExactPermutationTest([4,5,6],[1,2,3],mean), tail=:right), 0.05)
+    @testset "ExactPermutationTest" begin
+        @test pvalue(ExactPermutationTest([1,2,3], [4,5,6], mean), tail=:both) ≈ 0.1
+        @test pvalue(ExactPermutationTest([4,5,6], [1,2,3], mean), tail=:both) ≈ 0.1
+        @test pvalue(ExactPermutationTest([1,2,3], [4,5,6], mean), tail=:left) ≈ 0.05
+        @test pvalue(ExactPermutationTest([4,5,6], [1,2,3], mean), tail=:right) ≈ 0.05
+    end
 
-Random.seed!(12345)
-@test isapprox(pvalue(ApproximatePermutationTest([1,2,3],[4,5,6],mean,100), tail=:both), 0.09)
-@test isapprox(pvalue(ApproximatePermutationTest([4,5,6],[1,2,3],mean,100), tail=:both), 0.04)
-@test isapprox(pvalue(ApproximatePermutationTest([1,2,3],[4,5,6],mean,100), tail=:left), 0.08)
-@test isapprox(pvalue(ApproximatePermutationTest([4,5,6],[1,2,3],mean,100), tail=:right), 0.07)
+    @testset "ApproximatePermutationTest" begin
+        rng = StableRNG(12345)
+        @test pvalue(ApproximatePermutationTest(rng, [1,2,3], [4,5,6], mean, 100), tail=:both) ≈ 0.14
+        @test pvalue(ApproximatePermutationTest(rng, [4,5,6], [1,2,3], mean, 100), tail=:both) ≈ 0.08
+        @test pvalue(ApproximatePermutationTest(rng, [1,2,3], [4,5,6], mean, 100), tail=:left) ≈ 0.05
+        @test pvalue(ApproximatePermutationTest(rng, [4,5,6], [1,2,3], mean, 100), tail=:right) ≈ 0.05
+        # Test that the non-rng method works
+        @test ApproximatePermutationTest([4,5,6], [1,2,3], mean, 100) isa HypothesisTests.PermutationTest{Float64}
+    end
 end


### PR DESCRIPTION
Also, introduce an `rng` keyword argument in `ApproximatePermutationTest` to allow passing an `AbstractRNG` object. This avoid the reliance on the global RNG. I decided to use a keyword argument instead of using the first argument as we do for the `rand` methods. I think it's easier to use a keyword argument for functions that take many argument. Please comment if you disagree.