### PR TITLE
Update badges and TagBot action

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -9,3 +9,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DOCUMENTER_KEY }}

--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 *HypothesisTests.jl* is a Julia package that implements a wide range of hypothesis tests.
 
 - **Build & Testing Status:**
-  [![Build status](https://github.com/JuliaStats/HypothesisTests.jl/workflows/CI/badge.svg)](https://github.com/JuliaStats/HypothesisTests.jl/actions?query=workflow%3ACI+branch%3Amaster)
-  [![Coverage Status](https://coveralls.io/repos/JuliaStats/HypothesisTests.jl/badge.svg?branch=master)
-  ](https://coveralls.io/r/JuliaStats/HypothesisTests.jl?branch=master)
+[![Build Status](https://github.com/JuliaStats/HypothesisTests.jl/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/JuliaStats/HypothesisTests.jl/actions/workflows/ci.yml)
+[![Coverage Status](https://codecov.io/gh/JuliaStats/HypothesisTests.jl/branch/master/graph/badge.svg?token=ztSoTXYVhb)](https://codecov.io/gh/JuliaStats/HypothesisTests.jl)
 
 - **Documentation**: [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url]
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 *HypothesisTests.jl* is a Julia package that implements a wide range of hypothesis tests.
 
 - **Build & Testing Status:**
-[![Build Status](https://github.com/JuliaStats/HypothesisTests.jl/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/JuliaStats/HypothesisTests.jl/actions/workflows/ci.yml)
+[![Build Status](https://github.com/JuliaStats/HypothesisTests.jl/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/JuliaStats/HypothesisTests.jl/actions/workflows/ci.yml?query=branch%3Amaster)
 [![Coverage Status](https://codecov.io/gh/JuliaStats/HypothesisTests.jl/branch/master/graph/badge.svg?token=ztSoTXYVhb)](https://codecov.io/gh/JuliaStats/HypothesisTests.jl)
 
 - **Documentation**: [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url]


### PR DESCRIPTION
Badges are outdated and docs cannot be deployed automatically by TagBot without DOCUMENTER_KEY AFAICT.