### PR TITLE
Run CompatHelper also for docs subdirectory

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -12,5 +12,5 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}  # optional
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}  # trigger CI
+        run: julia -e 'using CompatHelper; CompatHelper.main(; subdirs = ["", "docs"])'


### PR DESCRIPTION
This PR should help to avoid ending up with outdated Documenter versions, as fixed by https://github.com/JuliaStats/HypothesisTests.jl/pull/260.