### PR TITLE
Fix some type instabilities of `pvalue` + `confint`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HypothesisTests"
 uuid = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
-version = "0.10.6"
+version = "0.10.7"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/HypothesisTests.jl
+++ b/src/HypothesisTests.jl
@@ -73,7 +73,8 @@ function pvalue(dist::ContinuousUnivariateDistribution, x::Number; tail=:both)
     check_tail(tail)
 
     if tail == :both
-        2 * min(cdf(dist, x), ccdf(dist, x))
+        p = 2 * min(cdf(dist, x), ccdf(dist, x))
+        min(p, oneunit(p)) # if P(X = x) > 0, then possibly p > 1
     elseif tail == :left
         cdf(dist, x)
     else # tail == :right
@@ -85,7 +86,8 @@ function pvalue(dist::DiscreteUnivariateDistribution, x::Number; tail=:both)
     check_tail(tail)
 
     if tail == :both
-        2 * min(ccdf(dist, x-1), cdf(dist, x))
+        p = 2 * min(ccdf(dist, x-1), cdf(dist, x))
+        min(p, oneunit(p)) # if P(X = x) > 0, then possibly p > 1
     elseif tail == :left
         cdf(dist, x)
     else # tail == :right

--- a/src/HypothesisTests.jl
+++ b/src/HypothesisTests.jl
@@ -73,7 +73,7 @@ function pvalue(dist::ContinuousUnivariateDistribution, x::Number; tail=:both)
     check_tail(tail)
 
     if tail == :both
-        min(2 * min(cdf(dist, x), ccdf(dist, x)), 1)
+        2 * min(cdf(dist, x), ccdf(dist, x))
     elseif tail == :left
         cdf(dist, x)
     else # tail == :right
@@ -85,7 +85,7 @@ function pvalue(dist::DiscreteUnivariateDistribution, x::Number; tail=:both)
     check_tail(tail)
 
     if tail == :both
-        min(2 * min(ccdf(dist, x-1), cdf(dist, x)), 1)
+        2 * min(ccdf(dist, x-1), cdf(dist, x))
     elseif tail == :left
         cdf(dist, x)
     else # tail == :right

--- a/src/HypothesisTests.jl
+++ b/src/HypothesisTests.jl
@@ -69,31 +69,39 @@ If `tail` is `:both` (default), then the p-value for the two-sided test is retur
 function pvalue end
 
 # Basic function for finding a p-value given a distribution and tail
-pvalue(dist::ContinuousUnivariateDistribution, x::Number; tail=:both) =
-    if tail == :both
-        min(2 * min(cdf(dist, x), ccdf(dist, x)), 1.0)
-    elseif tail == :left
-        cdf(dist, x)
-    elseif tail == :right
-        ccdf(dist, x)
-    else
-        throw(ArgumentError("tail=$(tail) is invalid"))
-    end
+function pvalue(dist::ContinuousUnivariateDistribution, x::Number; tail=:both)
+    check_tail(tail)
 
-pvalue(dist::DiscreteUnivariateDistribution, x::Number; tail=:both) =
     if tail == :both
-        min(2 * min(ccdf(dist, x-1), cdf(dist, x)), 1.0)
+        min(2 * min(cdf(dist, x), ccdf(dist, x)), 1)
     elseif tail == :left
         cdf(dist, x)
-    elseif tail == :right
-        ccdf(dist, x-1)
-    else
-        throw(ArgumentError("tail=$(tail) is invalid"))
+    else # tail == :right
+        ccdf(dist, x)
     end
+end
+
+function pvalue(dist::DiscreteUnivariateDistribution, x::Number; tail=:both)
+    check_tail(tail)
+
+    if tail == :both
+        min(2 * min(ccdf(dist, x-1), cdf(dist, x)), 1)
+    elseif tail == :left
+        cdf(dist, x)
+    else # tail == :right
+        ccdf(dist, x-1)
+    end
+end
 
 function check_level(level::Float64)
     if level >= 1 || level <= 0.5
         throw(ArgumentError("coverage level $level not in range (0.5, 1)"))
+    end
+end
+
+function check_tail(tail::Symbol)
+    if tail !== :both && tail !== :left && tail !== :right
+        throw(ArgumentError("tail=$(tail) is invalid"))
     end
 end
 

--- a/src/mann_whitney.jl
+++ b/src/mann_whitney.jl
@@ -153,7 +153,7 @@ function pvalue(x::ExactMannWhitneyUTest; tail=:both)
     else
         # Compute exact p-value by enumerating possible ranks in the tied data
         if tail == :both
-            min(1, 2 * minimum(mwuenumerate(x)))
+            min(1.0, 2 * minimum(mwuenumerate(x)))
         elseif tail == :left
             mwuenumerate(x)[1]
         else # tail == :right

--- a/src/mann_whitney.jl
+++ b/src/mann_whitney.jl
@@ -134,6 +134,8 @@ function mwuenumerate(x::ExactMannWhitneyUTest)
 end
 
 function pvalue(x::ExactMannWhitneyUTest; tail=:both)
+    check_tail(tail)
+
     if x.tie_adjustment == 0
         # Compute exact p-value using method from Rmath, which is fast but
         # cannot account for ties
@@ -145,10 +147,8 @@ function pvalue(x::ExactMannWhitneyUTest; tail=:both)
             end
         elseif tail == :left
             pwilcox(x.U, x.nx, x.ny, true)
-        elseif tail == :right
+        else # tail == :right
             pwilcox(x.U - 1, x.nx, x.ny, false)
-        else
-            throw(ArgumentError("tail=$(tail) is invalid"))
         end
     else
         # Compute exact p-value by enumerating possible ranks in the tied data
@@ -156,10 +156,8 @@ function pvalue(x::ExactMannWhitneyUTest; tail=:both)
             min(1, 2 * minimum(mwuenumerate(x)))
         elseif tail == :left
             mwuenumerate(x)[1]
-        elseif tail == :right
+        else # tail == :right
             mwuenumerate(x)[2]
-        else
-            throw(ArgumentError("tail=$(tail) is invalid"))
         end
     end
 end
@@ -223,15 +221,15 @@ function show_params(io::IO, x::ApproximateMannWhitneyUTest, ident)
 end
 
 function pvalue(x::ApproximateMannWhitneyUTest; tail=:both)
+    check_tail(tail)
+
     if x.mu == x.sigma == 0
-        1
-    else
-        if tail == :both
-            2 * ccdf(Normal(), abs(x.mu - 0.5 * sign(x.mu))/x.sigma)
-        elseif tail == :left
-            cdf(Normal(), (x.mu + 0.5)/x.sigma)
-        elseif tail == :right
-            ccdf(Normal(), (x.mu - 0.5)/x.sigma)
-        end
+        1.0
+    elseif tail == :both
+        2 * ccdf(Normal(), abs(x.mu - 0.5 * sign(x.mu))/x.sigma)
+    elseif tail == :left
+        cdf(Normal(), (x.mu + 0.5)/x.sigma)
+    else # tail == :right
+        ccdf(Normal(), (x.mu - 0.5)/x.sigma)
     end
 end

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -253,8 +253,8 @@ function calculate_ci(x::AbstractVector, level::Real=0.95; tail=:both)
     n = length(x)
     m = div(n * (n + 1), 2)
     k_range = 1:div(m, 2)
-    ks = [abs(1 - 2 * psignrank(i, n, true) - c) for i in k_range]
-    k = argmin(ks)
+    l = [1 - 2 * psignrank(i, n, true) for i in k_range]
+    k = argmin(abs.(l .- c))
     vals = Float64[]
     enumerated = enumerate(x)
     for (outer_index, outer_value) in enumerated

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -253,7 +253,8 @@ function calculate_ci(x::AbstractVector, level::Real=0.95; tail=:both)
     n = length(x)
     m = div(n * (n + 1), 2)
     k_range = 1:div(m, 2)
-    k = argmin(abs(1 - 2 * psignrank(i, n, true) - c) for i in k_range)
+    ks = [abs(1 - 2 * psignrank(i, n, true) - c) for i in k_range]
+    k = argmin(ks)
     vals = Float64[]
     enumerated = enumerate(x)
     for (outer_index, outer_value) in enumerated

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -3,54 +3,54 @@ using HypothesisTests: default_tail
 
 @testset "Mann-Whitney" begin
 @testset "Basic exact test" begin
-	@test abs(pvalue(ExactMannWhitneyUTest([1:10;], [2.1:2:21;])) - 0.0232) <= 1e-4
-	@test abs(pvalue(ExactMannWhitneyUTest([2.1:2:21;], [1:10;])) - 0.0232) <= 1e-4
-	@test abs(pvalue(ExactMannWhitneyUTest([1.5:10:100;], [2.1:2:21;])) - 0.0068) <= 1e-4
-	@test abs(pvalue(ExactMannWhitneyUTest([2.1:2:21;], [1.5:10:100;])) - 0.0068) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2.1:2:21;]))) - 0.0232) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2.1:2:21;], [1:10;]))) - 0.0232) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1.5:10:100;], [2.1:2:21;]))) - 0.0068) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2.1:2:21;], [1.5:10:100;]))) - 0.0068) <= 1e-4
 	@test default_tail(ExactMannWhitneyUTest([1:10;], [2.1:2:21;])) == :both
 	show(IOBuffer(), ExactMannWhitneyUTest([1:10;], [2.1:2:21;]))
 end
 
 @testset "Exact with ties" begin
-	@test abs(pvalue(ExactMannWhitneyUTest([1:10;], [1:10;])) - 1) <= 1e-4
-	@test abs(pvalue(ExactMannWhitneyUTest([1:10;], [2:11;])) - 0.5096) <= 1e-4
-	@test abs(pvalue(ExactMannWhitneyUTest([2:11;], [1:10;])) - 0.5096) <= 1e-4
-	@test abs(pvalue(ExactMannWhitneyUTest([1:10;], [1:5; ones(5)])) - 0.0057) <= 1e-4
-	@test abs(pvalue(ExactMannWhitneyUTest([1:5; ones(5)], [1:10;])) - 0.0057) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [1:10;]))) - 1) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:11;]))) - 0.5096) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2:11;], [1:10;]))) - 0.5096) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [1:5; ones(5)]))) - 0.0057) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:5; ones(5)], [1:10;]))) - 0.0057) <= 1e-4
 	show(IOBuffer(), ExactMannWhitneyUTest([1:10;], [1:10;]))
 end
 
 @testset "Exact with ties and unequal lengths" begin
-	@test abs(pvalue(ExactMannWhitneyUTest([1:10;], [2:2:24;])) - 0.0118) <= 1e-4
-	@test abs(pvalue(ExactMannWhitneyUTest([2:2:24;], [1:10;])) - 0.0118) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:2:24;]))) - 0.0118) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2:2:24;], [1:10;]))) - 0.0118) <= 1e-4
 	show(IOBuffer(), ExactMannWhitneyUTest([1:10;], [2:2:24;]))
 end
 
 @testset "Approximate test" begin
-	@test abs(pvalue(ApproximateMannWhitneyUTest([1:10;], [2.1:2:21;])) - 0.0257) <= 1e-4
-	@test abs(pvalue(ApproximateMannWhitneyUTest([2.1:2:21;], [1:10;])) - 0.0257) <= 1e-4
-	@test abs(pvalue(ApproximateMannWhitneyUTest([1.5:10:100;], [2.1:2:21;])) - 0.0091) <= 1e-4
-	@test abs(pvalue(ApproximateMannWhitneyUTest([2.1:2:21;], [1.5:10:100;])) - 0.0091) <= 1e-4
-	@test default_tail(ApproximateMannWhitneyUTest([1:10;], [2.1:2:21;])) == :both
+    @test abs(@inferred(pvalue(ApproximateMannWhitneyUTest([1:10;], [2.1:2:21;]))) - 0.0257) <= 1e-4
+    @test abs(@inferred(pvalue(ApproximateMannWhitneyUTest([2.1:2:21;], [1:10;]))) - 0.0257) <= 1e-4
+    @test abs(@inferred(pvalue(ApproximateMannWhitneyUTest([1.5:10:100;], [2.1:2:21;]))) - 0.0091) <= 1e-4
+    @test abs(@inferred(pvalue(ApproximateMannWhitneyUTest([2.1:2:21;], [1.5:10:100;]))) - 0.0091) <= 1e-4
+    @test default_tail(ApproximateMannWhitneyUTest([1:10;], [2.1:2:21;])) == :both
 	show(IOBuffer(), ApproximateMannWhitneyUTest([1:10;], [2.1:2:21;]))
 end
 
 @testset "Approximate with ties" begin
-	@test abs(pvalue(ApproximateMannWhitneyUTest([1:10;], [1:10;])) - 1) <= 1e-4
-	@test abs(pvalue(ApproximateMannWhitneyUTest([1:10;], [2:11;])) - 0.4948) <= 1e-4
-	@test abs(pvalue(ApproximateMannWhitneyUTest([2:11;], [1:10;])) - 0.4948) <= 1e-4
-	@test abs(pvalue(ApproximateMannWhitneyUTest([1:10;], [1:5; ones(5)])) - 0.0076) <= 1e-4
-	@test abs(pvalue(ApproximateMannWhitneyUTest([1:5; ones(5)], [1:10;])) - 0.0076) <= 1e-4
+    @test abs(@inferred(pvalue(ApproximateMannWhitneyUTest([1:10;], [1:10;]))) - 1) <= 1e-4
+    @test abs(@inferred(pvalue(ApproximateMannWhitneyUTest([1:10;], [2:11;]))) - 0.4948) <= 1e-4
+    @test abs(@inferred(pvalue(ApproximateMannWhitneyUTest([2:11;], [1:10;]))) - 0.4948) <= 1e-4
+    @test abs(@inferred(pvalue(ApproximateMannWhitneyUTest([1:10;], [1:5; ones(5)]))) - 0.0076) <= 1e-4
+    @test abs(@inferred(pvalue(ApproximateMannWhitneyUTest([1:5; ones(5)], [1:10;]))) - 0.0076) <= 1e-4
 	show(IOBuffer(), ApproximateMannWhitneyUTest([1:10;], [1:10;]))
 end
 
 @testset "Tests for automatic selection" begin
-	@test abs(pvalue(MannWhitneyUTest([1:10;], [2.1:2:21;])) - 0.0232) <= 1e-4
-	@test abs(pvalue(MannWhitneyUTest([1:10;], [2:11;])) - 0.4948) <= 1e-4
+    @test abs(@inferred(pvalue(MannWhitneyUTest([1:10;], [2.1:2:21;]))) - 0.0232) <= 1e-4
+    @test abs(@inferred(pvalue(MannWhitneyUTest([1:10;], [2:11;]))) - 0.4948) <= 1e-4
 	show(IOBuffer(), MannWhitneyUTest([1:10;], [2.1:2:21;]))
 end
 
 @testset "Issue #39" begin
-	@test abs(pvalue(ExactMannWhitneyUTest(Float32[1:10;], Float32[2:11;])) - 0.5096) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest(Float32[1:10;], Float32[2:11;]))) - 0.5096) <= 1e-4
 end
 end

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -3,74 +3,74 @@ using HypothesisTests: default_tail
 
 @testset "Wilcoxon" begin
 @testset "Basic exact test" begin
-	@test abs(pvalue(ExactSignedRankTest([1:10;], [2:2:20;])) - 0.0020) <= 1e-4
-	@test abs(pvalue(ExactSignedRankTest([2:2:20;], [1:10;])) - 0.0020) <= 1e-4
-	@test abs(pvalue(ExactSignedRankTest([1:10;], [2:2:16; -1; 1])) - 0.4316) <= 1e-4
-	@test abs(pvalue(ExactSignedRankTest([2:2:16; -1; 1], [1:10;])) - 0.4316) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [2:2:20;]))) - 0.0020) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([2:2:20;], [1:10;]))) - 0.0020) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [2:2:16; -1; 1]))) - 0.4316) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([2:2:16; -1; 1], [1:10;]))) - 0.4316) <= 1e-4
 	@test default_tail(ExactSignedRankTest([1:10;], [2:2:20;])) == :both
 	show(IOBuffer(), ExactSignedRankTest([1:10;], [2:2:20;]))
 end
 
 @testset "Exact with ties" begin
-	@test abs(pvalue(ExactSignedRankTest([1:10;], [1:10;])) - 1) <= 1e-4
-	@test abs(pvalue(ExactSignedRankTest([1:10;], [2:11;])) - 0.0020) <= 1e-4
-	@test abs(pvalue(ExactSignedRankTest([2:11;], [1:10;])) - 0.0020) <= 1e-4
-	@test abs(pvalue(ExactSignedRankTest(1:10, [1:5; ones(5)])) - 0.0625) <= 1e-4
-	@test abs(pvalue(ExactSignedRankTest([1:5; ones(5)], [1:10;])) - 0.0625) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [1:10;]))) - 1) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [2:11;]))) - 0.0020) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([2:11;], [1:10;]))) - 0.0020) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest(1:10, [1:5; ones(5)]))) - 0.0625) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([1:5; ones(5)], [1:10;]))) - 0.0625) <= 1e-4
 	show(IOBuffer(), ExactSignedRankTest([1:10;], [1:10;]))
 end
 
 @testset "Approximate test" begin
-	@test abs(pvalue(ApproximateSignedRankTest([1:10;], [2:2:20;])) - 0.005922) <= 1e-6
-	@test abs(pvalue(ApproximateSignedRankTest([2:2:20;], [1:10;])) - 0.005922) <= 1e-6
-	@test abs(pvalue(ApproximateSignedRankTest([1:10;], [2:2:16; -1; 1])) - 0.4148) <= 1e-4
-	@test abs(pvalue(ApproximateSignedRankTest([2:2:16; -1; 1], [1:10;])) - 0.4148) <= 1e-4
+    @test abs(@inferred(pvalue(ApproximateSignedRankTest([1:10;], [2:2:20;]))) - 0.005922) <= 1e-6
+    @test abs(@inferred(pvalue(ApproximateSignedRankTest([2:2:20;], [1:10;]))) - 0.005922) <= 1e-6
+    @test abs(@inferred(pvalue(ApproximateSignedRankTest([1:10;], [2:2:16; -1; 1]))) - 0.4148) <= 1e-4
+    @test abs(@inferred(pvalue(ApproximateSignedRankTest([2:2:16; -1; 1], [1:10;]))) - 0.4148) <= 1e-4
 	@test default_tail(ApproximateSignedRankTest([1:10;], [2:2:20;])) == :both
 	show(IOBuffer(), ApproximateSignedRankTest([1:10;], [2:2:20;]))
 end
 
 @testset "Approximate with ties" begin
-	@test abs(pvalue(ApproximateSignedRankTest([1:10;], [1:10;])) - 1) <= 1e-4
-	@test abs(pvalue(ApproximateSignedRankTest([1:10;], [2:11;])) - 0.001904) <= 1e-6
-	@test abs(pvalue(ApproximateSignedRankTest([2:11;], [1:10;])) - 0.001904) <= 1e-6
-	@test abs(pvalue(ApproximateSignedRankTest([1:10;], [1:5; ones(5)])) - 0.05906) <= 1e-5
-	@test abs(pvalue(ApproximateSignedRankTest([1:5; ones(5)], 1:10)) - 0.05906) <= 1e-5
+    @test abs(@inferred(pvalue(ApproximateSignedRankTest([1:10;], [1:10;]))) - 1) <= 1e-4
+    @test abs(@inferred(pvalue(ApproximateSignedRankTest([1:10;], [2:11;]))) - 0.001904) <= 1e-6
+    @test abs(@inferred(pvalue(ApproximateSignedRankTest([2:11;], [1:10;]))) - 0.001904) <= 1e-6
+    @test abs(@inferred(pvalue(ApproximateSignedRankTest([1:10;], [1:5; ones(5)]))) - 0.05906) <= 1e-5
+    @test abs(@inferred(pvalue(ApproximateSignedRankTest([1:5; ones(5)], 1:10))) - 0.05906) <= 1e-5
 	show(IOBuffer(), ApproximateSignedRankTest([1:10;], [1:10;]))
 end
 
 @testset "Tests for automatic selection" begin
-	@test abs(pvalue(SignedRankTest([1:10;], [2:2:20;])) - 0.0020) <= 1e-4
-	@test abs(pvalue(SignedRankTest([1:10;], [2:11;])) - 0.0020) <= 1e-4
+    @test abs(@inferred(pvalue(SignedRankTest([1:10;], [2:2:20;]))) - 0.0020) <= 1e-4
+    @test abs(@inferred(pvalue(SignedRankTest([1:10;], [2:11;]))) - 0.0020) <= 1e-4
 	@test default_tail(SignedRankTest([1:10;], [2:2:20;])) == :both
 	show(IOBuffer(), SignedRankTest([1:10;], [2:2:20;]))
 end
 
 @testset "One Sample tests" begin
 	# P-value computed using R wilcox.test
-	@test abs(pvalue(SignedRankTest([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] .- 10.1)) - 0.09460449) <= 1e-4
+    @test abs(@inferred(pvalue(SignedRankTest([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] .- 10.1))) - 0.09460449) <= 1e-4
 	# P-value computed using R wilcox.test
-	@test abs(pvalue(SignedRankTest([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16] .- 10.1)) - 0.1928101) <= 1e-4
+    @test abs(@inferred(pvalue(SignedRankTest([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16] .- 10.1))) - 0.1928101) <= 1e-4
 end
 
 @testset "One Sample tests with ties" begin
 	# P-value computed using R package exactRankTests wilcox.exact
-	@test abs(pvalue(SignedRankTest([1,2,3,4,5,6,7,10,10,10,10,10,13,14,15] .- 10.1)) - 0.04052734) <= 1e-4
+    @test abs(@inferred(pvalue(SignedRankTest([1,2,3,4,5,6,7,10,10,10,10,10,13,14,15] .- 10.1))) - 0.04052734) <= 1e-4
 	# P-value computed using R wilcox.test
-	@test abs(pvalue(SignedRankTest([1,2,3,4,5,6,7,10,10,10,10,10,13,14,15,16] .- 10.1)) - 0.1021964) <= 1e-4
+    @test abs(@inferred(pvalue(SignedRankTest([1,2,3,4,5,6,7,10,10,10,10,10,13,14,15,16] .- 10.1))) - 0.1021964) <= 1e-4
 end
 
 @testset "Issue 128" begin
-	@test pvalue(SignedRankTest([54.5, 54.5, 95.0, 51.5]), tail=:left)  == 1
-	@test pvalue(SignedRankTest([54.5, 54.5, 95.0, 51.5]), tail=:right) == 0.0625
+    @test @inferred(pvalue(SignedRankTest([54.5, 54.5, 95.0, 51.5]), tail=:left))  == 1
+    @test @inferred(pvalue(SignedRankTest([54.5, 54.5, 95.0, 51.5]), tail=:right)) == 0.0625
 end
 
 @testset "Test confidence interval" begin
-x = [-7.8, -6.9, -4.7, 3.7, 6.5, 8.7, 9.1, 10.1, 10.8, 13.6, 14.4, 16.6, 20.2, 22.4, 23.5]
-	@test isapprox(confint(ExactSignedRankTest(x))[1], 3.3, atol=1e-4)
-	@test isapprox(confint(ExactSignedRankTest(x))[2], 15.5, atol=1e-4)
-	@test isapprox(confint(ApproximateSignedRankTest(x))[1], 3.3, atol=1e-4)
-	@test isapprox(confint(ApproximateSignedRankTest(x))[2], 15.5, atol=1e-4)
-	@test isapprox(confint(SignedRankTest(x); tail=:left)[1], 4.45, atol=1e-4)
-	@test isapprox(confint(SignedRankTest(x); tail=:right)[2], 14.45, atol=1e-4)
+    x = [-7.8, -6.9, -4.7, 3.7, 6.5, 8.7, 9.1, 10.1, 10.8, 13.6, 14.4, 16.6, 20.2, 22.4, 23.5]
+    @test isapprox(@inferred(confint(ExactSignedRankTest(x)))[1], 3.3, atol=1e-4)
+    @test isapprox(@inferred(confint(ExactSignedRankTest(x)))[2], 15.5, atol=1e-4)
+    @test isapprox(@inferred(confint(ApproximateSignedRankTest(x)))[1], 3.3, atol=1e-4)
+    @test isapprox(@inferred(confint(ApproximateSignedRankTest(x)))[2], 15.5, atol=1e-4)
+    @test isapprox(@inferred(confint(SignedRankTest(x); tail=:left))[1], 4.45, atol=1e-4)
+    @test isapprox(@inferred(confint(SignedRankTest(x); tail=:right))[2], 14.45, atol=1e-4)
 end
 end


### PR DESCRIPTION
This PR fixes a part of https://github.com/JuliaStats/HypothesisTests.jl/issues/263.