### PR TITLE
Group docstrings for `pvalue` and `confint` with their tests

### DIFF
--- a/docs/src/methods.md
+++ b/docs/src/methods.md
@@ -1,15 +1,15 @@
 # Methods
 
+This page documents the generic `confint` and `pvalue` methods which are supported
+by most tests. Some particular tests support additional arguments: see the
+documentation for the relevant methods provided in sections covering these tests.
+
 ## Confidence interval
 ```@docs
 confint
-confint(::BinomialTest)
-confint(::PowerDivergenceTest)
-confint(::FisherExactTest)
 ```
 
 ## p-value
 ```@docs
 pvalue
-pvalue(::FisherExactTest)
 ```

--- a/docs/src/nonparametric.md
+++ b/docs/src/nonparametric.md
@@ -13,12 +13,15 @@ KSampleADTest
 
 ```@docs
 BinomialTest
+confint(::BinomialTest)
 ```
 
 ## Fisher exact test
 
 ```@docs
 FisherExactTest
+confint(::FisherExactTest)
+pvalue(::FisherExactTest)
 ```
 
 ## Kolmogorov-Smirnov test

--- a/docs/src/parametric.md
+++ b/docs/src/parametric.md
@@ -7,6 +7,7 @@ using HypothesisTests
 ## Power divergence test
 ```@docs
 PowerDivergenceTest
+confint(::PowerDivergenceTest)
 ```
 
 ## Pearson chi-squared test

--- a/src/binomial.jl
+++ b/src/binomial.jl
@@ -43,7 +43,9 @@ successes were encountered in `n` draws (or alternatively from which the vector 
 drawn) has success probability `p` against the alternative hypothesis that the success
 probability is not equal to `p`.
 
-Computed confidence intervals ([`confint`](@ref)) by default are Clopper-Pearson intervals.
+Computed confidence intervals by default are Clopper-Pearson intervals.
+See the [`confint(::BinomialTest)`](@ref) documentation for a list of
+supported methods to compute confidence intervals.
 
 Implements: [`pvalue`](@ref), [`confint(::BinomialTest)`](@ref)
 """

--- a/src/power_divergence.jl
+++ b/src/power_divergence.jl
@@ -255,6 +255,11 @@ marginals.
 
 Note that the entries of `x` (and `y` if provided) must be non-negative integers.
 
+Computed confidence intervals by default are Quesenberry-Hurst intervals
+if the minimum of the expected cell counts exceeds 100, and Sison-Glaz intervals otherwise.
+See the [`confint(::PowerDivergenceTest)`](@ref) documentation for a list of
+supported methods to compute confidence intervals.
+
 The power divergence test is given by
 ```math
     \\dfrac{2}{λ(λ+1)}\\sum_{i=1}^I \\sum_{j=1}^J n_{ij} \\left[(n_{ij}


### PR DESCRIPTION
It is much more logical to provide all the information about a test in a single place. Also add some information and links to docstrings (some tests already did this).