### PR TITLE
Remove `alpha` from docstrings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HypothesisTests"
 uuid = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
-version = "0.10.9"
+version = "0.10.10"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HypothesisTests"
 uuid = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
-version = "0.10.8"
+version = "0.10.9"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/HypothesisTests.jl
+++ b/src/HypothesisTests.jl
@@ -39,20 +39,20 @@ check_same_length(x::AbstractVector, y::AbstractVector) = if length(x) != length
 end
 
 """
-    confint(test::HypothesisTest; alpha = 0.05, tail = :both)
+    confint(test::HypothesisTest; level = 0.95, tail = :both)
 
-Compute a confidence interval C with coverage 1-`alpha`.
+Compute a confidence interval C with coverage `level`.
 
 If `tail` is `:both` (default), then a two-sided confidence interval is returned. If `tail`
 is `:left` or `:right`, then a one-sided confidence interval is returned.
 
 !!! note
     Most of the implemented confidence intervals are *strongly consistent*, that is, the
-    confidence interval with coverage 1-`alpha` does not contain the test statistic under
+    confidence interval with coverage `level` does not contain the test statistic under
     ``h_0`` if and only if the corresponding test rejects the null hypothesis
     ``h_0: θ = θ_0``:
     ```math
-        C (x, 1 − α) = \\{θ : p_θ (x) > α\\},
+        C (x, level) = \\{θ : p_θ (x) > 1 - level\\},
     ```
     where ``p_θ`` is the [`pvalue`](@ref) of the corresponding test.
 """

--- a/src/binomial.jl
+++ b/src/binomial.jl
@@ -77,7 +77,7 @@ of the following methods. Possible values for `method` are:
 
   - `:clopper_pearson` (default): Clopper-Pearson interval is based on the binomial
     distribution. The empirical coverage is never less than the nominal coverage of
-    1-`alpha`; it is usually too conservative.
+    `level`; it is usually too conservative.
   - `:wald`: Wald (or normal approximation) interval relies on the standard approximation of
     the actual binomial distribution by a normal distribution. Coverage can be erratically
     poor for success probabilities close to zero or one.

--- a/src/power_divergence.jl
+++ b/src/power_divergence.jl
@@ -44,7 +44,7 @@ default_tail(test::PowerDivergenceTest) = :right
 pvalue(x::PowerDivergenceTest; tail=:right) = pvalue(Chisq(x.df),x.stat; tail=tail)
 
 """
-    confint(test::PowerDivergenceTest; alpha = 0.05, tail = :both, method = :auto)
+    confint(test::PowerDivergenceTest; level = 0.95, tail = :both, method = :auto)
 
 Compute a confidence interval with coverage `level` for multinomial proportions using
 one of the following methods. Possible values for `method` are:


### PR DESCRIPTION
Fixes https://github.com/JuliaStats/HypothesisTests.jl/issues/268. It seems the implementation only supports `level` but the docstrings mentioned `alpha`.