### PR TITLE
Enable the two sided KG Test to deal with Ties.

### DIFF
--- a/src/kolmogorov_smirnov.jl
+++ b/src/kolmogorov_smirnov.jl
@@ -163,9 +163,6 @@ Implements: [`pvalue`](@ref)
 """
 function ApproximateTwoSampleKSTest(x::AbstractVector{T}, y::AbstractVector{S}) where {T<:Real, S<:Real}
     n_x, n_y = length(x), length(y)
-    if n_x+n_y > length(unique([x; y]))
-        @warn("This test is inaccurate with ties")
-    end
 
     ApproximateTwoSampleKSTest(ksstats(x, y)...)
 end
@@ -194,11 +191,30 @@ end
 # compute supremum of differences between empirical cdfs.
 function ksstats(x::AbstractVector{T}, y::AbstractVector{S}) where {T<:Real, S<:Real}
     n_x, n_y = length(x), length(y)
-    sort_idx = sortperm([x; y])
-    pdf_diffs = [ones(n_x)/n_x; -ones(n_y)/n_y][sort_idx]
-    cdf_diffs = cumsum(pdf_diffs)
-    δp = maximum(cdf_diffs)
-    δn = -minimum(cdf_diffs)
-    δ = max(δp, δn)
-    (n_x, n_y, δ, δp, δn)
-end
+    all_values = [x; y]
+    sort_idx = sortperm(all_values)
+    δ_y = 1. / n_y
+    δ_x = 1. / n_x
+    δ = 0.
+    δp = 0.
+    δn = 0.
+
+    for i in 1:(n_x + n_y)
+        if sort_idx[i] > n_x
+            δ -= δ_y
+        else
+            δ += δ_x
+        end
+
+        # only update δp/δn if the value is about to change or at the last step.
+        if ( i == n_x + n_y ) || ( all_values[sort_idx[i]] != all_values[sort_idx[i+1]] )
+            if δ > δp
+                δp = δ
+            elseif δ < δn
+                δn = δ
+            end
+        end
+    end
+
+    (n_x, n_y, max(δp, -δn), δp, -δn)
+end   

--- a/src/kolmogorov_smirnov.jl
+++ b/src/kolmogorov_smirnov.jl
@@ -193,11 +193,9 @@ function ksstats(x::AbstractVector{T}, y::AbstractVector{S}) where {T<:Real, S<:
     n_x, n_y = length(x), length(y)
     all_values = [x; y]
     sort_idx = sortperm(all_values)
-    δ_y = 1. / n_y
-    δ_x = 1. / n_x
-    δ = 0.
-    δp = 0.
-    δn = 0.
+    δ_y = 1 / n_y
+    δ_x = 1 / n_x
+    δ = δp = δn = zero(δ_y)
 
     for i in 1:(n_x + n_y)
         if sort_idx[i] > n_x

--- a/src/kolmogorov_smirnov.jl
+++ b/src/kolmogorov_smirnov.jl
@@ -205,7 +205,7 @@ function ksstats(x::AbstractVector{T}, y::AbstractVector{S}) where {T<:Real, S<:
         end
 
         # only update δp/δn if the value is about to change or at the last step.
-        if ( i == n_x + n_y ) || ( all_values[sort_idx[i]] != all_values[sort_idx[i+1]] )
+        if i == n_x + n_y || all_values[sort_idx[i]] != all_values[sort_idx[i + 1]]
             if δ > δp
                 δp = δ
             elseif δ < δn

--- a/test/kolmogorov_smirnov.jl
+++ b/test/kolmogorov_smirnov.jl
@@ -81,4 +81,11 @@ t = ExactOneSampleKSTest(x, Uniform())
 @test pvalue(t) ≈ 0.4351284228580825
 @test pvalue(t; tail=:left) ≈ 0.3013310572470338
 @test pvalue(t; tail=:right) ≈ 0.2193143479950862
+
+# Check two samples with ties
+
+t = ApproximateTwoSampleKSTest(ones(10), ones(10))
+@test isapprox(t.δ, 0., atol=1e-16)
+@test isapprox(t.δp, 0., atol=1e-16)
+@test isapprox(t.δn, 0., atol=1e-16)
 end


### PR DESCRIPTION
Performance is comparable, fewer allocations.