### PR TITLE
Pearson's Chi-Squared Test with 2 vectors

### DIFF
--- a/src/power_divergence.jl
+++ b/src/power_divergence.jl
@@ -387,6 +387,11 @@ function ChisqTest(x::AbstractVector{T}, y::AbstractVector{T}, k::T) where T<:In
     PowerDivergenceTest(d, lambda=1.0)
 end
 
+function ChisqTest(x::AbstractVector{T}, y::AbstractVector{T}) where {T<:Integer}
+    theta0 = y ./ sum(y)
+    PowerDivergenceTest(reshape(x, length(x), 1), lambda=1.0, theta0=theta0)
+end
+
 ChisqTest(x::AbstractVector{T}, theta0::Vector{U} = ones(length(x))/length(x)) where {T<:Integer,U<:AbstractFloat} =
     PowerDivergenceTest(reshape(x, length(x), 1), lambda=1.0, theta0=theta0)
 

--- a/src/power_divergence.jl
+++ b/src/power_divergence.jl
@@ -362,6 +362,11 @@ a goodness-of-fit test is performed (`x` is treated as a one-dimensional conting
 table). In this case, the hypothesis tested is whether the population probabilities equal
 those in `theta0`, or are all equal if `theta0` is not given.
 
+If only `y` and `x` are given and both are vectors of integer type, then once again a
+goodness-of-fit test is performed. In this case, `theta0` is calculated by the proportion
+of each individual values in `y`. Here, the hypothesis tested is whether the two samples
+`x` and `y` come from the same population or not.
+
 If `x` is a matrix with at least two rows and columns, it is taken as a two-dimensional
 contingency table. Otherwise, `x` and `y` must be vectors of the same length. The contingency
 table is calculated using `counts` function from the `StatsBase` package. Then the power

--- a/test/power_divergence.jl
+++ b/test/power_divergence.jl
@@ -198,4 +198,28 @@ MultinomialLRTest(x,y,(1:3,1:3))
 d = [113997 1031298
      334453 37471]
 PowerDivergenceTest(d)
+
+# Pearson's Chi-Squared Test
+# As in https://en.wikipedia.org/wiki/Pearson's_chi-squared_test#Fairness_of_dice
+O = [5,8,9,8,10,20]
+E = fill(10,6)
+m = ChisqTest(O,E)
+
+@test pvalue(m) ≈ 0.01990522033477436
+@test m.stat ≈ 13.4
+@test m.df == 5
+@test m.n == 60
+@test m.residuals ≈ reshape([-1.5811388300841895,-0.6324555320336759,-0.31622776601683794,-0.6324555320336759, 0.0, 3.162277660168379],size(O))
+
+# As in https://en.wikipedia.org/wiki/Pearson's_chi-squared_test#Goodness_of_fit
+O = [44,56]
+E = fill(50,2)
+m = ChisqTest(O,E)
+
+@test pvalue(m) ≈ 0.23013934044341544
+@test m.stat ≈ 1.44
+@test m.df == 1
+@test m.n == 100
+@test m.residuals ≈ reshape([-0.848528137423857,0.848528137423857],size(O))
+
 end


### PR DESCRIPTION
This commit tries to address issue #277 

- Added Pearson's Chi-Squared Test with 2 vectors of `integer` type
- Added tests for the said function

This commit works on the idea mentioned in [here](https://github.com/JuliaStats/HypothesisTests.jl/issues/277#issuecomment-1192952372).