### PR TITLE
Modified Jarque-Bera test (Urzua, 1996)

### DIFF
--- a/test/jarque_bera.jl
+++ b/test/jarque_bera.jl
@@ -41,6 +41,12 @@ t = JarqueBeraTest(sim_data_h0)
 @test default_tail(t) == :right
 show(IOBuffer(), t)
 
+t = JarqueBeraTest(sim_data_h0; adjusted=true)
+
+@test t.JB ≈ 0.9170583190120135
+@test pvalue(t) ≈ 0.6322128462414497
+show(IOBuffer(), t)
+
 sim_data_h1 = [
     0, 1, 0, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1,
     0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 1, 0, 0,
@@ -57,4 +63,11 @@ t = JarqueBeraTest(sim_data_h1)
 @test pvalue(t) ≈ 0.00020338498134114293
 @test default_tail(t) == :right
 show(IOBuffer(), t)
+
+t = JarqueBeraTest(sim_data_h1; adjusted=true)
+
+@test t.JB ≈ 18.529299970269175
+@test pvalue(t) ≈ 9.471388144608105e-5
+show(IOBuffer(), t)
+
 end


### PR DESCRIPTION
This commit adds the Adjusted Lagrangian Multiplier by Urzua, 1996 (as proposed [here](https://www.sciencedirect.com/science/article/abs/pii/S0165176596009238?via%3Dihub)) as a modification to the Jarque-Bera test for small and medium sample sizes.

This is an attempt to fill in one gap in issue #201 