### PR TITLE
Use `allunique`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HypothesisTests"
 uuid = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/kolmogorov_smirnov.jl
+++ b/src/kolmogorov_smirnov.jl
@@ -63,8 +63,8 @@ sample is not drawn from `d`.
 
 Implements: [`pvalue`](@ref)
 """
-function ExactOneSampleKSTest(x::AbstractVector{T}, d::UnivariateDistribution) where T<:Real
-    if length(x) > length(unique(x))
+function ExactOneSampleKSTest(x::AbstractVector{<:Real}, d::UnivariateDistribution)
+    if !allunique(x)
         @warn("This test is inaccurate with ties")
     end
 
@@ -107,8 +107,8 @@ that the sample is not drawn from `d`.
 
 Implements: [`pvalue`](@ref)
 """
-function ApproximateOneSampleKSTest(x::AbstractVector{T}, d::UnivariateDistribution) where T<:Real
-    if length(x) > length(unique(x))
+function ApproximateOneSampleKSTest(x::AbstractVector{<:Real}, d::UnivariateDistribution)
+    if !allunique(x)
         @warn("This test is inaccurate with ties")
     end
 


### PR DESCRIPTION
This PR contains a minor optimization: Instead of computing `unique(x)` and comparing its length with the length of `x`, it just checks `allunique(x)`.