### PR TITLE
remove psignrank from Rmath

### DIFF
--- a/src/HypothesisTests.jl
+++ b/src/HypothesisTests.jl
@@ -27,7 +27,7 @@ module HypothesisTests
 using Statistics, Random, LinearAlgebra
 using Distributions, Roots, StatsBase
 using Combinatorics: combinations, permutations
-using Rmath: pwilcox, psignrank
+using Rmath: pwilcox
 using Printf: @printf
 
 import StatsAPI

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -181,7 +181,7 @@ function psignrank(W::Union{Float64, Int}, n::Int, lower_tail::Bool)
             DP[i] += DP[i + j]
         end
     end
-    return sum(ldexp.(float.(DP), -n))
+    return sum(Base.Fix2(ldexp, -n) ∘ float, DP)
 end
 
 StatsAPI.confint(x::ExactSignedRankTest; level::Real=0.95, tail=:both) = calculate_ci(x.vals, level, tail=tail)

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -1,5 +1,6 @@
 using HypothesisTests, Test
 using HypothesisTests: default_tail
+using Rmath
 
 @testset "Wilcoxon" begin
 @testset "Basic exact test" begin
@@ -72,5 +73,29 @@ end
     @test isapprox(@inferred(confint(ApproximateSignedRankTest(x)))[2], 15.5, atol=1e-4)
     @test isapprox(@inferred(confint(SignedRankTest(x); tail=:left))[1], 4.45, atol=1e-4)
     @test isapprox(@inferred(confint(SignedRankTest(x); tail=:right))[2], 14.45, atol=1e-4)
+end
+
+@testset "Comparison psignrank with Rmath" begin
+    n = 4
+    for W in 0.0:sum(0:n)
+        @test isapprox(@inferred(HypothesisTests.psignrank(W, n, true)),
+                                 Rmath.psignrank.(W, n, true),
+                                 atol=1e-10)
+    end
+    for W in 0.0:sum(0:n)
+        @test isapprox(@inferred(HypothesisTests.psignrank(W, n, false)),
+                                 Rmath.psignrank(W-1, n, false),
+                                 atol=1e-10)
+    end
+    for W in 0:sum(0:n)
+        @test isapprox(@inferred(HypothesisTests.psignrank(W, n, true)),
+                                 Rmath.psignrank.(W, n, true),
+                                 atol=1e-10)
+    end
+    for W in 0:sum(0:n)
+        @test isapprox(@inferred(HypothesisTests.psignrank(W, n, false)),
+                                 Rmath.psignrank(W-1, n, false),
+                                 atol=1e-10)
+    end
 end
 end


### PR DESCRIPTION
This PR attempts to reimplement `psignrank` in pure Julia, to get rid of any GNU license issues with the R version @andreasnoack .
The Rmath version returns the exact correct decimal number, while my version has some slight floating point error.
I'm not sure why this is because, the Rmath version also containts floating point operations:
https://github.com/JuliaStats/Rmath-julia/blob/6f2d37ff112914d65559bc3e0035b325c11cf361/src/signrank.c#L161
```jl
julia> @btime HypothesisTests.psignrank.(0:sum(0:n), n, true)
  1.030 μs (38 allocations: 5.41 KiB)
11-element Vector{Float64}:
 0.0625
 0.12500000000000003
 0.18750000000000003
 0.3125
 0.4375
 0.5625000000000001
 0.6875000000000001
 0.8125000000000001
 0.8749999999999999
 0.9375000000000001
 1.0
 
 julia> @btime Rmath.psignrank.(0:sum(0:n), n, true)
  1.950 μs (5 allocations: 256 bytes)
11-element Vector{Float64}:
 0.0625
 0.125
 0.1875
 0.3125
 0.4375
 0.5625
 0.6875
 0.8125
 0.875
 0.9375
 1.0


julia> @btime HypothesisTests.psignrank.(0:sum(0:n), n, false)
  1.130 μs (38 allocations: 5.41 KiB)
11-element Vector{Float64}:
 1.0
 0.9375000000000001
 0.8749999999999999
 0.8125000000000001
 0.6875000000000001
 0.5625000000000001
 0.4375
 0.3125
 0.18750000000000003
 0.12500000000000003
 0.0625


julia> @btime Rmath.psignrank.((0:sum(0:n)).-1, n, false)
  1.960 μs (6 allocations: 288 bytes)
11-element Vector{Float64}:
 1.0
 0.9375
 0.875
 0.8125
 0.6875
 0.5625
 0.4375
 0.3125
 0.1875
 0.125
 0.0625
```