### PR TITLE
Allow vector of groups as an input for variance equality tests

### DIFF
--- a/src/var_equality.jl
+++ b/src/var_equality.jl
@@ -198,10 +198,15 @@ function FlignerKilleenTest(groups::AbstractVector{<:Real}...)
     # calculate scores
     Zᵢⱼ = [abs.(g .- median(g)) for g in groups]
     # rank scores
-    (ranks, tieadj) = tiedrank_adj(vcat(Zᵢⱼ...))
+    (ranks, tieadj) = tiedrank_adj(reduce(vcat, Zᵢⱼ))
     qᵢⱼ = quantile.(Normal(), 0.5 .+ ranks ./ 2(length(ranks) + 1))
-    Nᵢ = pushfirst!(cumsum([length(g) for g in groups]), 0)
-    Qᵢⱼ = [qᵢⱼ[(Nᵢ[i]+1):(Nᵢ[i+1])] for i in 1:length(Nᵢ)-1]
+    lastᵢ = 0
+    Qᵢⱼ = map(groups) do gᵢ
+        n = length(gᵢ)
+        qᵢ = view(qᵢⱼ, (lastᵢ + 1):(lastᵢ + n))
+        lastᵢ += n
+        return qᵢ
+    end
     # anova
     Nᵢ, SStᵢ, SSeᵢ = anova(Qᵢⱼ...)
     k = length(Nᵢ)

--- a/src/var_equality.jl
+++ b/src/var_equality.jl
@@ -60,9 +60,9 @@ end
 function anova(scores::AbstractVector{<:Real}...)
     Nᵢ = [length(g) for g in scores]
     Z̄ᵢ = mean.(scores)
-    Z̄ = mean(Z̄ᵢ)
-    SStᵢ = Nᵢ .* (Z̄ᵢ .- Z̄).^2
-    SSeᵢ = sum.( (z .- z̄).^2 for (z, z̄) in zip(scores, Z̄ᵢ) )
+    Z̄ = dot(Z̄ᵢ, Nᵢ) / sum(Nᵢ)
+    SStᵢ = Nᵢ .* abs2.(Z̄ᵢ .- Z̄)
+    SSeᵢ = [sum(z -> abs2(z - z̄ᵢ), scoresᵢ) for (scoresᵢ, z̄ᵢ) in zip(scores, Z̄ᵢ)]
     (Nᵢ, SStᵢ, SSeᵢ)
 end
 

--- a/src/var_equality.jl
+++ b/src/var_equality.jl
@@ -90,7 +90,7 @@ function OneWayANOVATest(groups::AbstractVector{<:Real}...)
     Nᵢ, SStᵢ, SSeᵢ = anova(groups...)
     k = length(Nᵢ)
     VarianceEqualityTest{FDist}(Nᵢ, SStᵢ, SSeᵢ, k-1, sum(Nᵢ)-k,
-        ("One-way analysis of variance (ANOVA) test","Means","F"))
+        ("One-way analysis of variance (ANOVA) test", "Means", "F"))
 end
 
 """
@@ -141,7 +141,7 @@ function LeveneTest(groups::AbstractVector{<:Real}...; scorediff=abs, statistic=
     Nᵢ, SStᵢ, SSeᵢ = anova(Zᵢⱼ...)
     k = length(Nᵢ)
     VarianceEqualityTest{FDist}(Nᵢ, SStᵢ, SSeᵢ, k-1, sum(Nᵢ)-k,
-        ("Levene's test","Variances","W"))
+        ("Levene's test", "Variances", "W"))
 end
 
 """
@@ -199,12 +199,12 @@ function FlignerKilleenTest(groups::AbstractVector{<:Real}...)
     Zᵢⱼ = [abs.(g .- median(g)) for g in groups]
     # rank scores
     (ranks, tieadj) = tiedrank_adj(vcat(Zᵢⱼ...))
-    qᵢⱼ = quantile.(Normal(),0.5 .+ ranks./2(length(ranks)+1))
-    Nᵢ = pushfirst!(cumsum([length(g) for g in groups]),0)
+    qᵢⱼ = quantile.(Normal(), 0.5 .+ ranks ./ 2(length(ranks) + 1))
+    Nᵢ = pushfirst!(cumsum([length(g) for g in groups]), 0)
     Qᵢⱼ = [qᵢⱼ[(Nᵢ[i]+1):(Nᵢ[i+1])] for i in 1:length(Nᵢ)-1]
     # anova
     Nᵢ, SStᵢ, SSeᵢ = anova(Qᵢⱼ...)
     k = length(Nᵢ)
-    t3 = VarianceEqualityTest{Chisq}(Nᵢ, SStᵢ, SSeᵢ, k-1, sum(Nᵢ)-k,
-            ("Fligner-Killeen test","Variances","FK"))
+    VarianceEqualityTest{Chisq}(Nᵢ, SStᵢ, SSeᵢ, k-1, sum(Nᵢ)-k,
+        ("Fligner-Killeen test", "Variances", "FK"))
 end

--- a/src/var_equality.jl
+++ b/src/var_equality.jl
@@ -58,8 +58,9 @@ function Base.show(io::IOContext, t::VarianceEqualityTest)
 end
 
 function anova(scores)
-    !isempty(scores) && all(Base.Fix2(isa, AbstractVector{<:Real}), scores) ||
+    if isempty(scores) || !all(x -> x isa AbstractVector{<:Real}, scores)
         throw(ArgumentError("`anova` requires a non-empty collection of vectors of `Real` numbers"))
+    end
 
     Nᵢ = [length(s) for s in scores]
     Z̄ᵢ = map(mean, scores)

--- a/test/var_equality.jl
+++ b/test/var_equality.jl
@@ -71,9 +71,8 @@ using DelimitedFiles
         # Columns are gear diameter and batch number
         gear = readdlm(joinpath(@__DIR__, "data", "gear.txt"))
         samples = reshape(gear[:, 1], :, 10)
-        groups2 = tuple((samples[:, i] for i in 1:size(samples, 1))...)
 
-        l = BrownForsytheTest(groups2...)
+        l = BrownForsytheTest(collect(eachcol(samples)))
         @test nobs(l) == fill(10, 10)
         @test dof(l) == (9, 90)
         @test HypothesisTests.teststatistic(l) ≈ 1.705910 atol=1e-5

--- a/test/var_equality.jl
+++ b/test/var_equality.jl
@@ -29,7 +29,7 @@ using DelimitedFiles
     ]
     t = OneWayANOVATest(groups...)
     @test nobs(t) == [7, 8, 8, 6]
-    @test dof(t) == (3,25)
+    @test dof(t) == (3, 25)
     @test pvalue(t) ≈ 0.072 atol=1e-3
     @test occursin("reject h_0", sprint(show, t))
 
@@ -49,7 +49,7 @@ using DelimitedFiles
     l = LeveneTest(groups...; statistic=median)
     @test pvalue(l) ≈ 0.97971 atol=1e-4
     # with 10% trimmed means
-    l = LeveneTest(groups...; statistic=v->mean(trim(v, prop=0.1)))
+    l = LeveneTest(groups...; statistic=v -> mean(trim(v, prop=0.1)))
     @test pvalue(l) ≈ 0.90357 atol=1e-4
 
     # Fligner-Killeen Test
@@ -64,13 +64,13 @@ using DelimitedFiles
 
     # Columns are gear diameter and batch number
     gear = readdlm(joinpath(@__DIR__, "data", "gear.txt"))
-    samples = reshape(gear[:,1],:,10)
-    groups2 = tuple((samples[:,i] for i in 1:size(samples,1))...)
+    samples = reshape(gear[:, 1], :, 10)
+    groups2 = tuple((samples[:, i] for i in 1:size(samples, 1))...)
 
     # Brown-Forsythe Test
     l = BrownForsytheTest(groups2...)
     @test nobs(l) == fill(10, 10)
-    @test dof(l) == (9,90)
+    @test dof(l) == (9, 90)
     @test HypothesisTests.teststatistic(l) ≈ 1.705910 atol=1e-5
     @test pvalue(l) ≈ 0.0991 atol=1e-4
     @test occursin("reject h_0", sprint(show, l))

--- a/test/var_equality.jl
+++ b/test/var_equality.jl
@@ -29,7 +29,7 @@ using DelimitedFiles
         @test dof(t2) == dof(t)
         @test pvalue(t2) == pvalue(t)
         @test HypothesisTests.teststatistic(t2) == HypothesisTests.teststatistic(t)
-        @test sprint(show, t2) == sprint(show, t)
+        @test repr(t2) == repr(t)
 
         # test tuple version
         t3 = OneWayANOVATest((groups...))
@@ -37,7 +37,7 @@ using DelimitedFiles
         @test dof(t3) == dof(t)
         @test pvalue(t3) == pvalue(t)
         @test HypothesisTests.teststatistic(t3) == HypothesisTests.teststatistic(t)
-        @test sprint(show, t3) == sprint(show, t)
+        @test repr(t3) == repr(t)
 
         # test generator version
         t4 = OneWayANOVATest(g for g in groups)
@@ -45,7 +45,7 @@ using DelimitedFiles
         @test dof(t4) == dof(t)
         @test pvalue(t4) == pvalue(t)
         @test HypothesisTests.teststatistic(t4) == HypothesisTests.teststatistic(t)
-        @test sprint(show, t4) == sprint(show, t)
+        @test repr(t4) == repr(t)
 
         show(IOContext(IOBuffer(), :table => true), t)
         show(IOBuffer(), t)
@@ -84,7 +84,7 @@ using DelimitedFiles
         @test dof(l2) == dof(l)
         @test pvalue(l2) == pvalue(l)
         @test HypothesisTests.teststatistic(l2) == HypothesisTests.teststatistic(l)
-        @test sprint(show, l2) == sprint(show, l)
+        @test repr(l2) == repr(l)
 
         # with medians
         l = LeveneTest(groups; statistic=median)
@@ -108,7 +108,7 @@ using DelimitedFiles
         @test dof(t2) == dof(t)
         @test pvalue(t2) == pvalue(t)
         @test HypothesisTests.teststatistic(t2) == HypothesisTests.teststatistic(t)
-        @test sprint(show, t2) == sprint(show, t)
+        @test repr(t2) == repr(t)
     end
 
     @testset "Brown-Forsythe" begin
@@ -129,6 +129,6 @@ using DelimitedFiles
         @test dof(l2) == dof(l)
         @test HypothesisTests.teststatistic(l2) == HypothesisTests.teststatistic(l)
         @test pvalue(l2) == pvalue(l)
-        @test sprint(show, l2) == sprint(show, l)
+        @test repr(l2) == repr(l)
     end
 end

--- a/test/var_equality.jl
+++ b/test/var_equality.jl
@@ -11,11 +11,19 @@ using DelimitedFiles
             [8, 12, 9, 11, 6, 8],
             [13, 9, 11, 8, 7, 12]
         ]
-        t = OneWayANOVATest(groups...)
+        t = OneWayANOVATest(groups)
         @test nobs(t) == fill(6, 3)
         @test dof(t) == (2,15)
         @test pvalue(t) ≈ 0.002 atol=1e-3
         @test occursin("reject h_0", sprint(show, t))
+
+        # test splatting version
+        t2 = OneWayANOVATest(groups...)
+        @test nobs(t2) == nobs(t)
+        @test dof(t2) == dof(t)
+        @test pvalue(t2) == pvalue(t)
+        @test HypothesisTests.teststatistic(t2) == HypothesisTests.teststatistic(t)
+        @test sprint(show, t2) == sprint(show, t)
 
         show(IOContext(IOBuffer(), :table => true), t)
         show(IOBuffer(), t)
@@ -27,7 +35,7 @@ using DelimitedFiles
             [79, 84, 74, 98, 63, 83, 85, 58],
             [85, 80, 65, 71, 67, 51],
         ]
-        t = OneWayANOVATest(groups...)
+        t = OneWayANOVATest(groups)
         @test nobs(t) == [7, 8, 8, 6]
         @test dof(t) == (3, 25)
         @test pvalue(t) ≈ 0.07276 atol=1e-6
@@ -44,26 +52,41 @@ using DelimitedFiles
     ]
     @testset "Levene" begin
         # with means
-        l = LeveneTest(groups...; statistic=mean)
+        l = LeveneTest(groups; statistic=mean)
         @test nobs(l) == fill(8, 4)
         @test dof(l) == (3,28)
         @test pvalue(l) ≈ 0.90357 atol=1e-4
 
+        l2 = LeveneTest(groups...; statistic=mean)
+        @test nobs(l2) == nobs(l)
+        @test dof(l2) == dof(l)
+        @test pvalue(l2) == pvalue(l)
+        @test HypothesisTests.teststatistic(l2) == HypothesisTests.teststatistic(l)
+        @test sprint(show, l2) == sprint(show, l)
+
         # with medians
-        l = LeveneTest(groups...; statistic=median)
+        l = LeveneTest(groups; statistic=median)
         @test pvalue(l) ≈ 0.97971 atol=1e-4
         # with 10% trimmed means
-        l = LeveneTest(groups...; statistic=v -> mean(trim(v, prop=0.1)))
+        l = LeveneTest(groups; statistic=v -> mean(trim(v, prop=0.1)))
         @test pvalue(l) ≈ 0.90357 atol=1e-4
     end
 
     @testset "Fligner-Killeen" begin
-        t = FlignerKilleenTest(groups...)
+        t = FlignerKilleenTest(groups)
         @test nobs(t) == fill(8, 4)
         @test dof(t) == 3
         @test pvalue(t) ≈ 0.9878 atol=1e-4
         @test HypothesisTests.teststatistic(t) ≈ 0.1311 atol=1e-5
         @test occursin("reject h_0", sprint(show, t))
+
+        # test splatting version
+        t2 = FlignerKilleenTest(groups...)
+        @test nobs(t2) == nobs(t)
+        @test dof(t2) == dof(t)
+        @test pvalue(t2) == pvalue(t)
+        @test HypothesisTests.teststatistic(t2) == HypothesisTests.teststatistic(t)
+        @test sprint(show, t2) == sprint(show, t)
     end
 
     @testset "Brown-Forsythe" begin
@@ -78,5 +101,12 @@ using DelimitedFiles
         @test HypothesisTests.teststatistic(l) ≈ 1.705910 atol=1e-5
         @test pvalue(l) ≈ 0.0991 atol=1e-4
         @test occursin("reject h_0", sprint(show, l))
+
+        l2 = BrownForsytheTest(eachcol(samples)...)
+        @test nobs(l2) == nobs(l)
+        @test dof(l2) == dof(l)
+        @test HypothesisTests.teststatistic(l2) == HypothesisTests.teststatistic(l)
+        @test pvalue(l2) == pvalue(l)
+        @test sprint(show, l2) == sprint(show, l)
     end
 end

--- a/test/var_equality.jl
+++ b/test/var_equality.jl
@@ -5,6 +5,12 @@ using DelimitedFiles
 
 @testset "Equality of Variances" begin
     @testset "One-way ANOVA" begin
+        # input checks
+        @test_throws ArgumentError OneWayANOVATest([])
+        @test_throws ArgumentError OneWayANOVATest(["A", "B"])
+        @test_throws ArgumentError OneWayANOVATest([["A", "B"], ["C", "D"]])
+        @test_throws MethodError OneWayANOVATest(["A", "B"], ["C", "D"])
+
         # https://en.wikipedia.org/wiki/One-way_analysis_of_variance#Example
         groups = [
             [6, 8, 4, 5, 3, 4],

--- a/test/var_equality.jl
+++ b/test/var_equality.jl
@@ -4,35 +4,36 @@ using Statistics
 using DelimitedFiles
 
 @testset "Equality of Variances" begin
+    @testset "One-way ANOVA" begin
+        # https://en.wikipedia.org/wiki/One-way_analysis_of_variance#Example
+        groups = [
+            [6, 8, 4, 5, 3, 4],
+            [8, 12, 9, 11, 6, 8],
+            [13, 9, 11, 8, 7, 12]
+        ]
+        t = OneWayANOVATest(groups...)
+        @test nobs(t) == fill(6, 3)
+        @test dof(t) == (2,15)
+        @test pvalue(t) ≈ 0.002 atol=1e-3
+        @test occursin("reject h_0", sprint(show, t))
 
-    # https://en.wikipedia.org/wiki/One-way_analysis_of_variance#Example
-    groups = [
-        [6, 8, 4, 5, 3, 4],
-        [8, 12, 9, 11, 6, 8],
-        [13, 9, 11, 8, 7, 12]
-    ]
-    t = OneWayANOVATest(groups...)
-    @test nobs(t) == fill(6, 3)
-    @test dof(t) == (2,15)
-    @test pvalue(t) ≈ 0.002 atol=1e-3
-    @test occursin("reject h_0", sprint(show, t))
+        show(IOContext(IOBuffer(), :table => true), t)
+        show(IOBuffer(), t)
 
-    show(IOContext(IOBuffer(), :table => true), t)
-    show(IOBuffer(), t)
-
-    # http://www.real-statistics.com/one-way-analysis-of-variance-anova/confidence-interval-anova/
-    groups = [
-        [51, 87, 50, 48, 79, 61, 53],
-        [82, 91, 92, 80, 52, 79, 73, 74],
-        [79, 84, 74, 98, 63, 83, 85, 58],
-        [85, 80, 65, 71, 67, 51],
-    ]
-    t = OneWayANOVATest(groups...)
-    @test nobs(t) == [7, 8, 8, 6]
-    @test dof(t) == (3, 25)
-    @test pvalue(t) ≈ 0.07276 atol=1e-6
-    @test HypothesisTests.teststatistic(t) ≈ 2.62311 atol=1e-6
-    @test occursin("reject h_0", sprint(show, t))
+        # http://www.real-statistics.com/one-way-analysis-of-variance-anova/confidence-interval-anova/
+        groups = [
+            [51, 87, 50, 48, 79, 61, 53],
+            [82, 91, 92, 80, 52, 79, 73, 74],
+            [79, 84, 74, 98, 63, 83, 85, 58],
+            [85, 80, 65, 71, 67, 51],
+        ]
+        t = OneWayANOVATest(groups...)
+        @test nobs(t) == [7, 8, 8, 6]
+        @test dof(t) == (3, 25)
+        @test pvalue(t) ≈ 0.07276 atol=1e-6
+        @test HypothesisTests.teststatistic(t) ≈ 2.62311 atol=1e-6
+        @test occursin("reject h_0", sprint(show, t))
+    end
 
     # http://www.real-statistics.com/one-way-analysis-of-variance-anova/homogeneity-variances/levenes-test/
     groups = [
@@ -41,38 +42,42 @@ using DelimitedFiles
         [79, 84, 74, 98, 63, 83, 85, 58],
         [85, 80, 65, 71, 67, 51, 63, 93],
     ]
-    # with means
-    l = LeveneTest(groups...; statistic=mean)
-    @test nobs(l) == fill(8, 4)
-    @test dof(l) == (3,28)
-    @test pvalue(l) ≈ 0.90357 atol=1e-4
-    # with medians
-    l = LeveneTest(groups...; statistic=median)
-    @test pvalue(l) ≈ 0.97971 atol=1e-4
-    # with 10% trimmed means
-    l = LeveneTest(groups...; statistic=v -> mean(trim(v, prop=0.1)))
-    @test pvalue(l) ≈ 0.90357 atol=1e-4
+    @testset "Levene" begin
+        # with means
+        l = LeveneTest(groups...; statistic=mean)
+        @test nobs(l) == fill(8, 4)
+        @test dof(l) == (3,28)
+        @test pvalue(l) ≈ 0.90357 atol=1e-4
 
-    # Fligner-Killeen Test
-    t = FlignerKilleenTest(groups...)
-    @test nobs(t) == fill(8, 4)
-    @test dof(t) == 3
-    @test pvalue(t) ≈ 0.9878 atol=1e-4
-    @test HypothesisTests.teststatistic(t) ≈ 0.1311 atol=1e-5
-    @test occursin("reject h_0", sprint(show, t))
+        # with medians
+        l = LeveneTest(groups...; statistic=median)
+        @test pvalue(l) ≈ 0.97971 atol=1e-4
+        # with 10% trimmed means
+        l = LeveneTest(groups...; statistic=v -> mean(trim(v, prop=0.1)))
+        @test pvalue(l) ≈ 0.90357 atol=1e-4
+    end
 
-    # https://www.itl.nist.gov/div898/handbook/eda/section3/eda35a.htm
+    @testset "Fligner-Killeen" begin
+        t = FlignerKilleenTest(groups...)
+        @test nobs(t) == fill(8, 4)
+        @test dof(t) == 3
+        @test pvalue(t) ≈ 0.9878 atol=1e-4
+        @test HypothesisTests.teststatistic(t) ≈ 0.1311 atol=1e-5
+        @test occursin("reject h_0", sprint(show, t))
+    end
 
-    # Columns are gear diameter and batch number
-    gear = readdlm(joinpath(@__DIR__, "data", "gear.txt"))
-    samples = reshape(gear[:, 1], :, 10)
-    groups2 = tuple((samples[:, i] for i in 1:size(samples, 1))...)
+    @testset "Brown-Forsythe" begin
+        # https://www.itl.nist.gov/div898/handbook/eda/section3/eda35a.htm
+        # Columns are gear diameter and batch number
+        gear = readdlm(joinpath(@__DIR__, "data", "gear.txt"))
+        samples = reshape(gear[:, 1], :, 10)
+        groups2 = tuple((samples[:, i] for i in 1:size(samples, 1))...)
 
-    # Brown-Forsythe Test
-    l = BrownForsytheTest(groups2...)
-    @test nobs(l) == fill(10, 10)
-    @test dof(l) == (9, 90)
-    @test HypothesisTests.teststatistic(l) ≈ 1.705910 atol=1e-5
-    @test pvalue(l) ≈ 0.0991 atol=1e-4
-    @test occursin("reject h_0", sprint(show, l))
+        l = BrownForsytheTest(groups2...)
+        @test nobs(l) == fill(10, 10)
+        @test dof(l) == (9, 90)
+        @test HypothesisTests.teststatistic(l) ≈ 1.705910 atol=1e-5
+        @test pvalue(l) ≈ 0.0991 atol=1e-4
+        @test occursin("reject h_0", sprint(show, l))
+    end
 end

--- a/test/var_equality.jl
+++ b/test/var_equality.jl
@@ -1,6 +1,6 @@
 using HypothesisTests
 using Test
-using Statistics
+using StatsBase
 using DelimitedFiles
 
 @testset "Equality of Variances" begin

--- a/test/var_equality.jl
+++ b/test/var_equality.jl
@@ -30,7 +30,8 @@ using DelimitedFiles
     t = OneWayANOVATest(groups...)
     @test nobs(t) == [7, 8, 8, 6]
     @test dof(t) == (3, 25)
-    @test pvalue(t) ≈ 0.072 atol=1e-3
+    @test pvalue(t) ≈ 0.07276 atol=1e-6
+    @test HypothesisTests.teststatistic(t) ≈ 2.62311 atol=1e-6
     @test occursin("reject h_0", sprint(show, t))
 
     # http://www.real-statistics.com/one-way-analysis-of-variance-anova/homogeneity-variances/levenes-test/

--- a/test/var_equality.jl
+++ b/test/var_equality.jl
@@ -25,6 +25,22 @@ using DelimitedFiles
         @test HypothesisTests.teststatistic(t2) == HypothesisTests.teststatistic(t)
         @test sprint(show, t2) == sprint(show, t)
 
+        # test tuple version
+        t3 = OneWayANOVATest((groups...))
+        @test nobs(t3) == nobs(t)
+        @test dof(t3) == dof(t)
+        @test pvalue(t3) == pvalue(t)
+        @test HypothesisTests.teststatistic(t3) == HypothesisTests.teststatistic(t)
+        @test sprint(show, t3) == sprint(show, t)
+
+        # test generator version
+        t4 = OneWayANOVATest(g for g in groups)
+        @test nobs(t4) == nobs(t)
+        @test dof(t4) == dof(t)
+        @test pvalue(t4) == pvalue(t)
+        @test HypothesisTests.teststatistic(t4) == HypothesisTests.teststatistic(t)
+        @test sprint(show, t4) == sprint(show, t)
+
         show(IOContext(IOBuffer(), :table => true), t)
         show(IOBuffer(), t)
 


### PR DESCRIPTION
Currently, one-way ANOVA and other variance equality tests require that each group of values is passed as a separate argument (`OneWayAnova([1, 2], [1, 2, 3])`).
When the user has a vector of groups (`groups = [[1, 2], [1, 2, 3]]`), it is therefore required to splat it when passing to the tests (`OneWayAnova(groups...)`).
That adds unnecessary overhead to the Julia compiler, especially when the number of groups is large -- the execution becomes extremely slow.

The PR changes the var-equality tests to accept the vector of groups as the input.
The "splatting" variants of the functions are converted to call the vector-based ones.

The PR also includes the modified version of the #273 fix -- but I will also welcome if that PR is merged first.
