### PR TITLE
Add tests of left-tail + right-tail p-values for exact Mann-Whitney U and signed rank tests

### DIFF
--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -44,7 +44,7 @@ end
     @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [1:10;]); tail = :left)) - 0.5296) <= 1e-4
     @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:11;]); tail = :left)) - 0.2548) <= 1e-4
     @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2:11;], [1:10;]); tail = :left)) - 0.7634) <= 1e-4
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [1:5; ones(5)]); tail = :left)) - 0.9978) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [1:5; ones(5)]); tail = :left)) - 0.9979) <= 1e-4
     @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:5; ones(5)], [1:10;]); tail = :left)) - 0.0028) <= 1e-4
 
     # Right tail
@@ -52,7 +52,7 @@ end
     @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:11;]); tail = :right)) - 0.7634) <= 1e-4
     @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2:11;], [1:10;]); tail = :right)) - 0.2548) <= 1e-4
     @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [1:5; ones(5)]); tail = :right)) - 0.0028) <= 1e-4
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:5; ones(5)], [1:10;]); tail = :right)) - 0.9978) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:5; ones(5)], [1:10;]); tail = :right)) - 0.9979) <= 1e-4
 end
 
 @testset "Exact with ties and unequal lengths" begin
@@ -65,12 +65,12 @@ end
     end
 
     # Left tail
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:2:24;]); tail = :left)) - 0.9948) <= 1e-4
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2:2:24;], [1:10;]); tail = :left)) - 0.9948) <= 1e-4
+    @test_broken abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:2:24;]); tail = :left)) - 0.0060) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2:2:24;], [1:10;]); tail = :left)) - 0.9949) <= 1e-4
 
     # Right tail
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:2:24;]); tail = :right)) - 0.0058) <= 1e-4
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2:2:24;], [1:10;]); tail = :right)) - 0.0058) <= 1e-4
+    @test_broken abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:2:24;]); tail = :right)) - 0.9949) <= 1e-4
+    @test_broken abs(@inferred(pvalue(ExactMannWhitneyUTest([2:2:24;], [1:10;]); tail = :right)) - 0.0060) <= 1e-4
 end
 
 @testset "Approximate test" begin

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -3,27 +3,74 @@ using HypothesisTests: default_tail
 
 @testset "Mann-Whitney" begin
 @testset "Basic exact test" begin
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2.1:2:21;]))) - 0.0232) <= 1e-4
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2.1:2:21;], [1:10;]))) - 0.0232) <= 1e-4
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1.5:10:100;], [2.1:2:21;]))) - 0.0068) <= 1e-4
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2.1:2:21;], [1.5:10:100;]))) - 0.0068) <= 1e-4
 	@test default_tail(ExactMannWhitneyUTest([1:10;], [2.1:2:21;])) == :both
 	show(IOBuffer(), ExactMannWhitneyUTest([1:10;], [2.1:2:21;]))
+
+    # Two-sided
+    for kwargs in ((), (; tail = :both))
+        @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2.1:2:21;]); kwargs...)) - 0.0232) <= 1e-4
+        @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2.1:2:21;], [1:10;]); kwargs...)) - 0.0232) <= 1e-4
+        @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1.5:10:100;], [2.1:2:21;]); kwargs...)) - 0.0068) <= 1e-4
+        @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2.1:2:21;], [1.5:10:100;]); kwargs...)) - 0.0068) <= 1e-4
+    end
+
+    # Left tail
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2.1:2:21;]); tail = :left)) - 0.0116) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2.1:2:21;], [1:10;]); tail = :left)) - 0.9907) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1.5:10:100;], [2.1:2:21;]); tail = :left)) - 0.9974) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2.1:2:21;], [1.5:10:100;]); tail = :left)) - 0.0034) <= 1e-4
+
+
+    # Right tail
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2.1:2:21;]); tail = :right)) - 0.9907) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2.1:2:21;], [1:10;]); tail = :right)) - 0.0116) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1.5:10:100;], [2.1:2:21;]); tail = :right)) - 0.0034) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2.1:2:21;], [1.5:10:100;]); tail = :right)) - 0.9974) <= 1e-4
 end
 
 @testset "Exact with ties" begin
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [1:10;]))) - 1) <= 1e-4
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:11;]))) - 0.5096) <= 1e-4
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2:11;], [1:10;]))) - 0.5096) <= 1e-4
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [1:5; ones(5)]))) - 0.0057) <= 1e-4
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:5; ones(5)], [1:10;]))) - 0.0057) <= 1e-4
-	show(IOBuffer(), ExactMannWhitneyUTest([1:10;], [1:10;]))
+    show(IOBuffer(), ExactMannWhitneyUTest([1:10;], [1:10;]))
+
+    # Two-sided
+    for kwargs in ((), (; tail = :both))
+        @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [1:10;]); kwargs...)) - 1) <= 1e-4
+        @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:11;]); kwargs...)) - 0.5096) <= 1e-4
+        @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2:11;], [1:10;]); kwargs...)) - 0.5096) <= 1e-4
+        @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [1:5; ones(5)]); kwargs...)) - 0.0057) <= 1e-4
+        @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:5; ones(5)], [1:10;]); kwargs...)) - 0.0057) <= 1e-4
+    end
+
+    # Left tail
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [1:10;]); tail = :left)) - 0.5296) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:11;]); tail = :left)) - 0.2548) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2:11;], [1:10;]); tail = :left)) - 0.7634) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [1:5; ones(5)]); tail = :left)) - 0.9978) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:5; ones(5)], [1:10;]); tail = :left)) - 0.0028) <= 1e-4
+
+    # Right tail
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [1:10;]); tail = :right)) - 0.5296) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:11;]); tail = :right)) - 0.7634) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2:11;], [1:10;]); tail = :right)) - 0.2548) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [1:5; ones(5)]); tail = :right)) - 0.0028) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:5; ones(5)], [1:10;]); tail = :right)) - 0.9978) <= 1e-4
 end
 
 @testset "Exact with ties and unequal lengths" begin
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:2:24;]))) - 0.0118) <= 1e-4
-    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2:2:24;], [1:10;]))) - 0.0118) <= 1e-4
-	show(IOBuffer(), ExactMannWhitneyUTest([1:10;], [2:2:24;]))
+    show(IOBuffer(), ExactMannWhitneyUTest([1:10;], [2:2:24;]))
+
+    # Two-sided
+    for kwargs in ((), (; tail = :both))
+        @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:2:24;]); kwargs...)) - 0.0118) <= 1e-4
+        @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2:2:24;], [1:10;]); kwargs...)) - 0.0118) <= 1e-4
+    end
+
+    # Left tail
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:2:24;]); tail = :left)) - 0.9948) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2:2:24;], [1:10;]); tail = :left)) - 0.9948) <= 1e-4
+
+    # Right tail
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2:2:24;]); tail = :right)) - 0.0058) <= 1e-4
+    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([2:2:24;], [1:10;]); tail = :right)) - 0.0058) <= 1e-4
 end
 
 @testset "Approximate test" begin

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -3,21 +3,55 @@ using HypothesisTests: default_tail
 
 @testset "Wilcoxon" begin
 @testset "Basic exact test" begin
-    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [2:2:20;]))) - 0.0020) <= 1e-4
-    @test abs(@inferred(pvalue(ExactSignedRankTest([2:2:20;], [1:10;]))) - 0.0020) <= 1e-4
-    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [2:2:16; -1; 1]))) - 0.4316) <= 1e-4
-    @test abs(@inferred(pvalue(ExactSignedRankTest([2:2:16; -1; 1], [1:10;]))) - 0.4316) <= 1e-4
-	@test default_tail(ExactSignedRankTest([1:10;], [2:2:20;])) == :both
+    @test default_tail(ExactSignedRankTest([1:10;], [2:2:20;])) == :both
 	show(IOBuffer(), ExactSignedRankTest([1:10;], [2:2:20;]))
+
+    # Two-sided
+    for kwargs in ((), (; tail = :both))
+        @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [2:2:20;]); kwargs...)) - 0.0020) <= 1e-4
+        @test abs(@inferred(pvalue(ExactSignedRankTest([2:2:20;], [1:10;]); kwargs...)) - 0.0020) <= 1e-4
+        @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [2:2:16; -1; 1]); kwargs...)) - 0.4316) <= 1e-4
+        @test abs(@inferred(pvalue(ExactSignedRankTest([2:2:16; -1; 1], [1:10;]); kwargs...)) - 0.4316) <= 1e-4
+    end
+
+    # Left tail
+    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [2:2:20;]); tail = :left)) - 0.0009) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([2:2:20;], [1:10;]); tail = :left)) - 1) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [2:2:16; -1; 1]); tail = :left)) - 0.2158) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([2:2:16; -1; 1], [1:10;]); tail = :left)) - 0.8125) <= 1e-4
+
+    # Right tail
+    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [2:2:20;]); tail = :right)) - 1) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([2:2:20;], [1:10;]); tail = :right)) - 0.0009) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [2:2:16; -1; 1]); tail = :right)) - 0.8125) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([2:2:16; -1; 1], [1:10;]); tail = :right)) - 0.2158) <= 1e-4
 end
 
 @testset "Exact with ties" begin
-    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [1:10;]))) - 1) <= 1e-4
-    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [2:11;]))) - 0.0020) <= 1e-4
-    @test abs(@inferred(pvalue(ExactSignedRankTest([2:11;], [1:10;]))) - 0.0020) <= 1e-4
-    @test abs(@inferred(pvalue(ExactSignedRankTest(1:10, [1:5; ones(5)]))) - 0.0625) <= 1e-4
-    @test abs(@inferred(pvalue(ExactSignedRankTest([1:5; ones(5)], [1:10;]))) - 0.0625) <= 1e-4
-	show(IOBuffer(), ExactSignedRankTest([1:10;], [1:10;]))
+    show(IOBuffer(), ExactSignedRankTest([1:10;], [1:10;]))
+
+    # Two-sided
+    for kwargs in ((), (; tail = :both))
+        @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [1:10;]); kwargs...)) - 1) <= 1e-4
+        @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [2:11;]); kwargs...)) - 0.0020) <= 1e-4
+        @test abs(@inferred(pvalue(ExactSignedRankTest([2:11;], [1:10;]); kwargs...)) - 0.0020) <= 1e-4
+        @test abs(@inferred(pvalue(ExactSignedRankTest(1:10, [1:5; ones(5)]); kwargs...)) - 0.0625) <= 1e-4
+        @test abs(@inferred(pvalue(ExactSignedRankTest([1:5; ones(5)], [1:10;]); kwargs...)) - 0.0625) <= 1e-4
+    end
+
+    # Left tail
+    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [1:10;]); tail = :left)) - 1) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [2:11;]); tail = :left)) - 0.0009) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([2:11;], [1:10;]); tail = :left)) - 1) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest(1:10, [1:5; ones(5)]); tail = :left)) - 1) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([1:5; ones(5)], [1:10;]); tail = :left)) - 0.0312) <= 1e-4
+
+    # Right tail
+    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [1:10;]); tail = :right)) - 1) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([1:10;], [2:11;]); tail = :right)) - 1) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([2:11;], [1:10;]); tail = :right)) - 0.0009) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest(1:10, [1:5; ones(5)]); tail = :right)) - 0.0312) <= 1e-4
+    @test abs(@inferred(pvalue(ExactSignedRankTest([1:5; ones(5)], [1:10;]); tail = :right)) - 1) <= 1e-4
 end
 
 @testset "Approximate test" begin


### PR DESCRIPTION
This PR increases test coverage: Currently, left-tail and right-tail p-values of these two hypothesis tests are not tested. This came up in #334. I moved the coverage changes to a separate PR to ensure that #334 does not introduce any regressions.

~~Since I was unable to reproduce even the existing two-sided p-values with R, the reference values added in this PR are based on HypothesisTests#master. Clearly they should be validated with some other software before merging this PR. As an example, the existing tests check~~
```julia
    @test abs(@inferred(pvalue(ExactMannWhitneyUTest([1:10;], [2.1:2:21;]))) - 0.0232) <= 1e-4
```
~~but with R I get completely different p-values:~~
```R
> wilcox.test(c(1:10), c(2.1:2:21), alternative="two.sided", exact=TRUE, correct=FALSE)


        Wilcoxon rank sum exact test

data:  c(1:10) and c(2.1:2:21)
W = 36, p-value = 0.00568
alternative hypothesis: true location shift is not equal to 0

> wilcox.test(c(1:10), c(2.1:2:21), alternative="two.sided", exact=TRUE, correct=TRUE)


        Wilcoxon rank sum exact test

data:  c(1:10) and c(2.1:2:21)
W = 36, p-value = 0.00568
alternative hypothesis: true location shift is not equal to 0
```
I assume I'm doing something wrong in R?! @ArnoStrouwen do you know how to validate the p-values with R?

Edit: Of course, it was a stupid mistake on my side.

```R
> c(2.1:2:21)

 [1]  2.1  3.1  4.1  5.1  6.1  7.1  8.1  9.1 10.1 11.1 12.1 13.1 14.1 15.1 16.1
[16] 17.1 18.1 19.1 20.1
> seq(2.1, 21, by=2)

 [1]  2.1  4.1  6.1  8.1 10.1 12.1 14.1 16.1 18.1 20.1

> wilcox.test(1:10, seq(2.1, 21, by=2), alternative="two.sided", exact=TRUE, correct=FALSE)


        Wilcoxon rank sum exact test

data:  1:10 and seq(2.1, 21, by = 2)
W = 20, p-value = 0.02323
alternative hypothesis: true location shift is not equal to 0
```