### PR TITLE
Require Julia 1.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           (needs.test.result != 'success') ||
           (needs.docs.result != 'success')
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -33,8 +33,6 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x64
     # needed to allow julia-actions/cache to delete old caches that it has created
     permissions:
       actions: write
@@ -44,7 +42,6 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ Statistics = "1"
 StatsAPI = "1.6"
 StatsBase = "0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33, 0.34"
 Test = "<0.0.1, 1"
-julia = "1.3"
+julia = "1.10"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/test/show.jl
+++ b/test/show.jl
@@ -5,55 +5,7 @@ using HypothesisTests, Test
 d = [[762,484] [327,239] [468,477]]
 m = PowerDivergenceTest(d)
 
-if VERSION < v"1.4"
-    @test sprint(show, m, context=:compact => true) ==
-    """
-    Pearson's Chi-square Test
-    -------------------------
-    Population details:
-        parameter of interest:   Multinomial Probabilities
-        value under h_0:         [0.255231, 0.19671, 0.11594, 0.0893561, 0.193574, 0.14919]
-        point estimate:          [0.276387, 0.175553, 0.118607, 0.0866884, 0.16975, 0.173014]
-        95% confidence interval: Tuple{Float64,Float64}[(0.2545, 0.2994), (0.1573, 0.1955), (0.1033, 0.1358), (0.07357, 0.1019), (0.1517, 0.1894), (0.1548, 0.1928)]
-
-    Test summary:
-        outcome with 95% confidence: reject h_0
-        one-sided p-value:           <1e-6
-
-    Details:
-        Sample size:        2757
-        statistic:          30.070149095754687
-        degrees of freedom: 2
-        residuals:          [2.19886, -2.50467, 0.41137, -0.468583, -2.84324, 3.23867]
-        std. residuals:     [4.50205, -4.50205, 0.699452, -0.699452, -5.31595, 5.31595]
-    """
-
-    d = [ 20, 15, 25 ]
-    m = PowerDivergenceTest(d)
-
-    @test sprint(show, m, context=:compact => true) ==
-    """
-    Pearson's Chi-square Test
-    -------------------------
-    Population details:
-        parameter of interest:   Multinomial Probabilities
-        value under h_0:         [0.333333, 0.333333, 0.333333]
-        point estimate:          [0.333333, 0.25, 0.416667]
-        95% confidence interval: Tuple{Float64,Float64}[(0.2167, 0.481), (0.1333, 0.3976), (0.3, 0.5643)]
-
-    Test summary:
-        outcome with 95% confidence: fail to reject h_0
-        one-sided p-value:           0.2865
-
-    Details:
-        Sample size:        60
-        statistic:          2.5
-        degrees of freedom: 2
-        residuals:          [0.0, -1.11803, 1.11803]
-        std. residuals:     [0.0, -1.36931, 1.36931]
-    """
-elseif VERSION < v"1.6"
-    @test sprint(show, m, context=:compact => true) ==
+@test sprint(show, m, context=:compact => true) ==
     """
     Pearson's Chi-square Test
     -------------------------
@@ -65,7 +17,7 @@ elseif VERSION < v"1.6"
 
     Test summary:
         outcome with 95% confidence: reject h_0
-        one-sided p-value:           <1e-6
+        one-sided p-value:           <1e-06
 
     Details:
         Sample size:        2757
@@ -75,10 +27,10 @@ elseif VERSION < v"1.6"
         std. residuals:     [4.50205, -4.50205, 0.699452, -0.699452, -5.31595, 5.31595]
     """
 
-    d = [ 20, 15, 25 ]
-    m = PowerDivergenceTest(d)
+d = [ 20, 15, 25 ]
+m = PowerDivergenceTest(d)
 
-    @test sprint(show, m, context=:compact => true) ==
+@test sprint(show, m, context=:compact => true) ==
     """
     Pearson's Chi-square Test
     -------------------------
@@ -99,54 +51,6 @@ elseif VERSION < v"1.6"
         residuals:          [0.0, -1.11803, 1.11803]
         std. residuals:     [0.0, -1.36931, 1.36931]
     """
-else
-    @test sprint(show, m, context=:compact => true) ==
-        """
-        Pearson's Chi-square Test
-        -------------------------
-        Population details:
-            parameter of interest:   Multinomial Probabilities
-            value under h_0:         [0.255231, 0.19671, 0.11594, 0.0893561, 0.193574, 0.14919]
-            point estimate:          [0.276387, 0.175553, 0.118607, 0.0866884, 0.16975, 0.173014]
-            95% confidence interval: [(0.2545, 0.2994), (0.1573, 0.1955), (0.1033, 0.1358), (0.07357, 0.1019), (0.1517, 0.1894), (0.1548, 0.1928)]
-
-        Test summary:
-            outcome with 95% confidence: reject h_0
-            one-sided p-value:           <1e-06
-
-        Details:
-            Sample size:        2757
-            statistic:          30.070149095754687
-            degrees of freedom: 2
-            residuals:          [2.19886, -2.50467, 0.41137, -0.468583, -2.84324, 3.23867]
-            std. residuals:     [4.50205, -4.50205, 0.699452, -0.699452, -5.31595, 5.31595]
-        """
-
-    d = [ 20, 15, 25 ]
-    m = PowerDivergenceTest(d)
-
-    @test sprint(show, m, context=:compact => true) ==
-        """
-        Pearson's Chi-square Test
-        -------------------------
-        Population details:
-            parameter of interest:   Multinomial Probabilities
-            value under h_0:         [0.333333, 0.333333, 0.333333]
-            point estimate:          [0.333333, 0.25, 0.416667]
-            95% confidence interval: [(0.2167, 0.481), (0.1333, 0.3976), (0.3, 0.5643)]
-
-        Test summary:
-            outcome with 95% confidence: fail to reject h_0
-            one-sided p-value:           0.2865
-
-        Details:
-            Sample size:        60
-            statistic:          2.5
-            degrees of freedom: 2
-            residuals:          [0.0, -1.11803, 1.11803]
-            std. residuals:     [0.0, -1.36931, 1.36931]
-        """
-end
 
 # based on t.jl tests
 tst = OneSampleTTest(-5:10)


### PR DESCRIPTION
Test error in #338 is due to `begin` not being supported in `@view` on Julia 1.3. I think it's OK to update the min Julia version to 1.10 instead of working around it.