### PR TITLE
Use `[sources]` in docs/Project.toml to manage self dependency

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,9 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+HypothesisTests = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
 
 [compat]
 Documenter = "1"
+
+[sources]
+HypothesisTests = {path = ".."}


### PR DESCRIPTION
Documentation for Pkg.jl feature is available at
https://pkgdocs.julialang.org/v1/toml-files/#The-[sources]-section

This also simplifies local development of the docs project since one can just run `]instantiate` in the docs environment without having to do a `dev .` in the root directory.