### PR TITLE
Add citation management with DocumenterCitations

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,9 +1,11 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 HypothesisTests = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
 
 [compat]
 Documenter = "1"
+DocumenterCitations = "1"
 HypothesisTests = "0.11"
 
 [sources]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,8 @@
-using Documenter, HypothesisTests
+using Documenter
+using DocumenterCitations
+using HypothesisTests
+
+bib = CitationBibliography(joinpath(@__DIR__, "src", "refs.bib"))
 
 makedocs(
     modules = [HypothesisTests],
@@ -10,8 +14,10 @@ makedocs(
         "nonparametric.md",
         "time_series.md",
         "multivariate.md",
+        "bibliography.md",
     ],
-    checkdocs = :exports
+    checkdocs = :exports,
+    plugins = [bib],
 )
 
 deploydocs(

--- a/docs/src/bibliography.md
+++ b/docs/src/bibliography.md
@@ -1,0 +1,3 @@
+# Bibliography
+```@bibliography
+```

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -1,0 +1,469 @@
+@book{agresti2013,
+  title = {Categorical Data Analysis},
+  author = {Agresti, Alan},
+  year = {2013},
+  series = {Wiley Series in Probability and Statistics},
+  edition = {3rd},
+  number = {792},
+  publisher = {Wiley},
+  address = {Hoboken, NJ},
+  isbn = {978-0-470-46363-5},
+  lccn = {QA278 .A353 2013}
+}
+
+@article{box1953,
+  title = {Non-Normality and Tests on Variances},
+  author = {Box, George E. P.},
+  year = {1953},
+  journal = {Biometrika},
+  volume = {40},
+  number = {3/4},
+  eprint = {2333350},
+  eprinttype = {jstor},
+  pages = {318},
+  issn = {00063444},
+  doi = {10.2307/2333350},
+  url = {https://www.jstor.org/stable/2333350}
+}
+
+@article{breusch1979,
+  title = {A Simple Test for Heteroscedasticity and Random Coefficient Variation},
+  author = {Breusch, T. S. and Pagan, A. R.},
+  year = {1979},
+  month = sep,
+  journal = {Econometrica},
+  volume = {47},
+  number = {5},
+  eprint = {1911963},
+  eprinttype = {jstor},
+  pages = {1287},
+  issn = {00129682},
+  doi = {10.2307/1911963}
+}
+
+@article{brown1974,
+  title = {Robust Tests for the Equality of Variances},
+  author = {Brown, Morton B. and Forsythe, Alan B.},
+  year = {1974},
+  month = jun,
+  journal = {Journal of the American Statistical Association},
+  volume = {69},
+  number = {346},
+  pages = {364--367},
+  issn = {0162-1459, 1537-274X},
+  doi = {10.1080/01621459.1974.10482955}
+}
+
+@article{brown2001,
+  title = {Interval Estimation for a Binomial Proportion},
+  author = {Brown, Lawrence D. and Cai, T. Tony and DasGupta, Anirban},
+  year = {2001},
+  month = may,
+  journal = {Statistical Science},
+  volume = {16},
+  number = {2},
+  pages = {101--117},
+  issn = {0883-4237},
+  doi = {10.1214/ss/1009213286}
+}
+
+@article{clark2006,
+  title = {Using Out-of-Sample Mean Squared Prediction Errors to Test the Martingale Difference Hypothesis},
+  author = {Clark, Todd E. and West, Kenneth D.},
+  year = {2006},
+  month = nov,
+  journal = {Journal of Econometrics},
+  volume = {135},
+  number = {1-2},
+  pages = {155--186},
+  issn = {03044076},
+  doi = {10.1016/j.jeconom.2005.07.014},
+  copyright = {https://www.elsevier.com/tdm/userlicense/1.0/}
+}
+
+@article{clark2007,
+  title = {Approximately Normal Tests for Equal Predictive Accuracy in Nested Models},
+  author = {Clark, Todd E. and West, Kenneth D.},
+  year = {2007},
+  month = may,
+  journal = {Journal of Econometrics},
+  volume = {138},
+  number = {1},
+  pages = {291--311},
+  issn = {03044076},
+  doi = {10.1016/j.jeconom.2006.05.023},
+  copyright = {https://www.elsevier.com/tdm/userlicense/1.0/}
+}
+
+@article{conover1981,
+  title = {A Comparative Study of Tests for Homogeneity of Variances, with Applications to the Outer Continental Shelf Bidding Data},
+  author = {Conover, W. J. and Johnson, Mark E. and Johnson, Myrle M.},
+  year = {1981},
+  month = nov,
+  journal = {Technometrics},
+  volume = {23},
+  number = {4},
+  pages = {351--361},
+  issn = {0040-1706, 1537-2723},
+  doi = {10.1080/00401706.1981.10487680}
+}
+
+@article{diebold1995,
+  title = {Comparing Predictive Accuracy},
+  author = {Diebold, Francis X. and Mariano, Roberto S.},
+  year = {1995},
+  month = jul,
+  journal = {Journal of Business \& Economic Statistics},
+  volume = {13},
+  number = {3},
+  pages = {253--263},
+  issn = {0735-0015, 1537-2707},
+  doi = {10.1080/07350015.1995.10524599}
+}
+
+@article{durbin1950,
+  title = {Testing for Serial Correlation in Least Squares Regression: I},
+  shorttitle = {Testing for Serial Correlation in Least Squares Regression},
+  author = {Durbin, J. and Watson, G. S.},
+  year = {1950},
+  month = dec,
+  journal = {Biometrika},
+  volume = {37},
+  number = {3/4},
+  eprint = {2332391},
+  eprinttype = {jstor},
+  pages = {409},
+  issn = {00063444},
+  doi = {10.2307/2332391},
+  url = {http://www.jstor.org/stable/2332391}
+}
+
+@article{durbin1951,
+  title = {Testing for Serial Correlation in Least Squares Regression: II},
+  author = {Durbin, J. and Watson, G. S.},
+  year = {1951},
+  month = jun,
+  journal = {Biometrika},
+  volume = {38},
+  number = {1/2},
+  eprint = {23323257},
+  eprinttype = {jstor},
+  pages = {159},
+  issn = {00063444},
+  doi = {10.2307/2332325},
+  url = {http://www.jstor.org/stable/2332325}
+}
+
+@article{durbin1971,
+  title = {Testing for Serial Correlation in Least Squares Regression: III},
+  author = {Durbin, J. and Watson, G. S.},
+  year = {1971},
+  month = apr,
+  journal = {Biometrika},
+  volume = {58},
+  number = {1},
+  eprint = {2334313},
+  eprinttype = {jstor},
+  pages = {1},
+  issn = {00063444},
+  doi = {10.2307/2334313},
+  url = {http://www.jstor.org/stable/2334313}
+}
+
+@article{farebrother1980,
+  title = {Algorithm AS 153: Pan's Procedure for the Tail Probabilities of the Durbin-Watson Statistic},
+  shorttitle = {Algorithm AS 153},
+  author = {Farebrother, R. W.},
+  year = {1980},
+  journal = {Applied Statistics},
+  volume = {29},
+  number = {2},
+  eprint = {10.2307/2986316},
+  eprinttype = {jstor},
+  pages = {224},
+  issn = {00359254},
+  doi = {10.2307/2986316},
+  url = {http://www.jstor.org/stable/2986316}
+}
+
+@article{fay2010,
+  title = {Confidence Intervals That Match Fisher's Exact or Blaker's Exact Tests},
+  author = {Fay, Michael P.},
+  year = {2010},
+  month = apr,
+  journal = {Biostatistics},
+  volume = {11},
+  number = {2},
+  pages = {373--374},
+  issn = {1468-4357, 1465-4644},
+  doi = {10.1093/biostatistics/kxp050},
+  url = {https://doi.org/10.1093/biostatistics/kxp050}
+}
+
+@article{gibbons1975,
+  title = {P-Values: Interpretation and Methodology},
+  shorttitle = {P-Values},
+  author = {Gibbons, Jean D. and Pratt, John W.},
+  year = {1975},
+  month = feb,
+  journal = {The American Statistician},
+  volume = {29},
+  number = {1},
+  pages = {20--25},
+  issn = {0003-1305, 1537-2731},
+  doi = {10.1080/00031305.1975.10479106}
+}
+
+@article{gold1963,
+  title = {Tests Auxiliary to $\chi^2$ Tests in a Markov Chain},
+  author = {Gold, Ruth Z.},
+  year = {1963},
+  month = mar,
+  journal = {The Annals of Mathematical Statistics},
+  volume = {34},
+  number = {1},
+  pages = {56--74},
+  issn = {0003-4851},
+  doi = {10.1214/aoms/1177704242}
+}
+
+@article{harvey1997,
+  title = {Testing the Equality of Prediction Mean Squared Errors},
+  author = {Harvey, David and Leybourne, Stephen and Newbold, Paul},
+  year = {1997},
+  month = jun,
+  journal = {International Journal of Forecasting},
+  volume = {13},
+  number = {2},
+  pages = {281--291},
+  issn = {01692070},
+  doi = {10.1016/S0169-2070(96)00719-4},
+  copyright = {https://www.elsevier.com/tdm/userlicense/1.0/}
+}
+
+@article{koenker1981,
+  title = {A Note on Studentizing a Test for Heteroscedasticity},
+  author = {Koenker, Roger},
+  year = {1981},
+  month = sep,
+  journal = {Journal of Econometrics},
+  volume = {17},
+  number = {1},
+  pages = {107--112},
+  issn = {03044076},
+  doi = {10.1016/0304-4076(81)90062-2},
+  copyright = {https://www.elsevier.com/tdm/userlicense/1.0/}
+}
+
+@article{levy1978,
+  title = {Testing Hypotheses Concerning Partial Correlations: Some Methods and Discussion},
+  shorttitle = {Testing Hypotheses Concerning Partial Correlations},
+  author = {Levy, Kenneth J. and Narula, Subhash C.},
+  year = {1978},
+  month = aug,
+  journal = {International Statistical Review},
+  volume = {46},
+  number = {2},
+  eprint = {1402814},
+  eprinttype = {jstor},
+  pages = {215},
+  issn = {03067734},
+  doi = {10.2307/1402814},
+  url = {https://www.jstor.org/stable/1402814}
+}
+
+@article{mackinnon1994,
+  title = {Approximate Asymptotic Distribution Functions for Unit-Root and Cointegration Tests},
+  author = {MacKinnon, James G.},
+  year = {1994},
+  month = apr,
+  journal = {Journal of Business \& Economic Statistics},
+  volume = {12},
+  number = {2},
+  pages = {167--176},
+  issn = {0735-0015, 1537-2707},
+  doi = {10.1080/07350015.1994.10510005},
+  url = {http://www.jstor.org/stable/1391481}
+}
+
+@techreport{mackinnon2010,
+  type = {Working Paper},
+  title = {Critical Values for Cointegration Tests},
+  author = {MacKinnon, James G.},
+  year = {2010},
+  number = {1227},
+  institution = {Queen's University},
+  url = {http://ideas.repec.org/p/qed/wpaper/1227.html}
+}
+
+@article{mantalos2011,
+  title = {Three Different Measures of Sample Skewness and Kurtosis and Their Effects on the Jarque Bera Test for Normality},
+  author = {Mantalos, Panagiotis},
+  year = {2011},
+  journal = {International Journal of Computational Economics and Econometrics},
+  volume = {2},
+  number = {1},
+  pages = {47},
+  issn = {1757-1170, 1757-1189},
+  doi = {10.1504/IJCEE.2011.040576},
+  url = {https://www.inderscience.com/offers.php?id=40576}
+}
+
+@misc{meyer2008,
+  title = {Expanded Table of the Kruskal-Wallis Statistic},
+  author = {Meyer, J. P. and Seaman, M. A.},
+  year = {2008},
+  annotation = {Three group critical value tables: https://web.archive.org/web/20181017173535/http://faculty.virginia.edu/kruskal-wallis/table/KW-expanded-tables-3groups.pdf\\
+\\
+Four group critical value tables: https://web.archive.org/web/20181017173535/http://faculty.virginia.edu/kruskal-wallis/table/KW-expanded-tables-4groups.pdf}
+}
+
+@article{meyer2013,
+  title = {A Comparison of the Exact Kruskal-Wallis Distribution to Asymptotic Approximations for All Sample Sizes up to 105},
+  author = {Meyer, J. Patrick and Seaman, Michael A.},
+  year = {2013},
+  month = jan,
+  journal = {The Journal of Experimental Education},
+  volume = {81},
+  number = {2},
+  pages = {139--156},
+  issn = {0022-0973, 1940-0683},
+  doi = {10.1080/00220973.2012.699904}
+}
+
+@article{pires2008,
+  title = {Interval Estimators for a Binomial Proportion: Comparison of Twenty Methods},
+  shorttitle = {Interval Estimators for a Binomial Proportion},
+  author = {Pires, Ana M. and Amado, Concei\c{c}{\~a}o},
+  year = {2008},
+  month = jun,
+  journal = {REVSTAT-Statistical Journal},
+  pages = {165--197},
+  publisher = {REVSTAT-Statistical Journal},
+  doi = {10.57805/REVSTAT.V6I2.63},
+  copyright = {Creative Commons Attribution 4.0 International}
+}
+
+@article{quesenberry1964,
+  title = {Large Sample Simultaneous Confidence Intervals for Multinomial Proportions},
+  author = {Quesenberry, C. P. and Hurst, D. C.},
+  year = {1964},
+  month = may,
+  journal = {Technometrics},
+  volume = {6},
+  number = {2},
+  pages = {191--195},
+  issn = {0040-1706, 1537-2723},
+  doi = {10.1080/00401706.1964.10490163}
+}
+
+@article{royston1992,
+  title = {Approximating the Shapiro-Wilk W-test for Non-Normality},
+  author = {Royston, Patrick},
+  year = {1992},
+  month = sep,
+  journal = {Statistics and Computing},
+  volume = {2},
+  number = {3},
+  pages = {117--119},
+  issn = {0960-3174, 1573-1375},
+  doi = {10.1007/BF01891203},
+  copyright = {http://www.springer.com/tdm}
+}
+
+@article{royston1993,
+  title = {A Toolkit for Testing for Non-Normality in Complete and Censored Samples},
+  author = {Royston, Patrick},
+  year = {1993},
+  journal = {The Statistician},
+  volume = {42},
+  number = {1},
+  eprint = {10.2307/2348109},
+  eprinttype = {jstor},
+  pages = {37},
+  issn = {00390526},
+  doi = {10.2307/2348109}
+}
+
+@article{royston1995,
+  title = {Remark AS R94: A Remark on Algorithm AS 181: The W-test for Normality},
+  shorttitle = {Remark AS R94},
+  author = {Royston, Patrick},
+  year = {1995},
+  journal = {Applied Statistics},
+  volume = {44},
+  number = {4},
+  eprint = {2986146},
+  eprinttype = {jstor},
+  pages = {547},
+  issn = {00359254},
+  doi = {10.2307/2986146}
+}
+
+@article{scholz1987,
+  title = {K-Sample Anderson--Darling Tests},
+  author = {Scholz, F. W. and Stephens, M. A.},
+  year = {1987},
+  month = sep,
+  journal = {Journal of the American Statistical Association},
+  volume = {82},
+  number = {399},
+  pages = {918--924},
+  issn = {0162-1459, 1537-274X},
+  doi = {10.1080/01621459.1987.10478517}
+}
+
+@article{shapiro1965,
+  title = {An Analysis of Variance Test for Normality (Complete Samples)},
+  author = {Shapiro, S. S. and Wilk, M. B.},
+  year = {1965},
+  month = dec,
+  journal = {Biometrika},
+  volume = {52},
+  number = {3-4},
+  pages = {591--611},
+  issn = {0006-3444, 1464-3510},
+  doi = {10.1093/biomet/52.3-4.591}
+}
+
+@article{sison1995,
+  title = {Simultaneous Confidence Intervals and Sample Size Determination for Multinomial Proportions},
+  author = {Sison, Cristina P. and Glaz, Joseph},
+  year = {1995},
+  month = mar,
+  journal = {Journal of the American Statistical Association},
+  volume = {90},
+  number = {429},
+  pages = {366--369},
+  issn = {0162-1459, 1537-274X},
+  doi = {10.1080/01621459.1995.10476521}
+}
+
+@article{urzua1996,
+  title = {On the Correct Use of Omnibus Tests for Normality},
+  author = {Urz{\'u}a, Carlos M.},
+  year = {1996},
+  month = dec,
+  journal = {Economics Letters},
+  volume = {53},
+  number = {3},
+  pages = {247--251},
+  issn = {01651765},
+  doi = {10.1016/S0165-1765(96)00923-8},
+  copyright = {https://www.elsevier.com/tdm/userlicense/1.0/}
+}
+
+@article{white1980,
+  title = {A Heteroskedasticity-Consistent Covariance Matrix Estimator and a Direct Test for Heteroskedasticity},
+  author = {White, Halbert},
+  year = {1980},
+  month = may,
+  journal = {Econometrica},
+  volume = {48},
+  number = {4},
+  eprint = {1912934},
+  eprinttype = {jstor},
+  pages = {817},
+  issn = {00129682},
+  doi = {10.2307/1912934}
+}

--- a/src/anderson_darling.jl
+++ b/src/anderson_darling.jl
@@ -111,8 +111,7 @@ Implements: [`pvalue`](@ref)
 
 # References
 
-  * F. W. Scholz and M. A. Stephens, K-Sample Anderson-Darling Tests, Journal of the
-    American Statistical Association, Vol. 82, No. 399. (Sep., 1987), pp. 918-924.
+  * [Scholz and Stephens (1987). K-Sample Anderson-Darling Tests](@cite scholz1987)
 """
 KSampleADTest(xs::AbstractVector{T}...; modified = true, nsim = 0) where T<:Real =
     a2_ksample(xs, modified, nsim)

--- a/src/augmented_dickey_fuller.jl
+++ b/src/augmented_dickey_fuller.jl
@@ -48,11 +48,9 @@ from those reported in other regression packages as different algorithms might b
 
 # References
 
-  * James G. MacKinnon, 2010, "Critical values for cointegration tests,"
-    QED Working Paper No. 1227, 2010, [link](http://ideas.repec.org/p/qed/wpaper/1227.html).
-  * James G. MacKinnon, 1994, "Approximate Asymptotic Distribution Functions for
-    Unit-Root and Cointegration Tests", Journal of Business & Economic Statistics,
-    Vol. 12, No. 2, pp. 167-176, [link](http://www.jstor.org/stable/1391481).
+  * [MacKinnon (2010). Critical values for cointegration tests](@cite mackinnon2010)
+  * [MacKinnon (1994). Approximate Asymptotic Distribution Functions for
+    Unit-Root and Cointegration Tests](@cite mackinnon1994)
 
 # External links
 

--- a/src/binomial.jl
+++ b/src/binomial.jl
@@ -96,7 +96,7 @@ of the following methods. Possible values for `method` are:
 
 # References
 
-  * [Brown, Cai, and DasGupta (2001). Interval estimation for a binomial proportion.](@cite brown2001)
+  * [Brown, Cai, and DasGupta (2001). Interval estimation for a binomial proportion](@cite brown2001)
   * [Pires and Amado (2008). Interval Estimators for a Binomial Proportion:
      Comparison of Twenty Methods](@cite pires2008)
 

--- a/src/binomial.jl
+++ b/src/binomial.jl
@@ -96,10 +96,9 @@ of the following methods. Possible values for `method` are:
 
 # References
 
-  * Brown, L.D., Cai, T.T., and DasGupta, A. Interval estimation for a binomial proportion.
-    Statistical Science, 16(2):101–117, 2001.
-  * Pires, Ana & Amado, Conceição. (2008). Interval Estimators for a Binomial Proportion: 
-    Comparison of Twenty Methods. REVSTAT. 6. 10.57805/revstat.v6i2.63.
+  * [Brown, Cai, and DasGupta (2001). Interval estimation for a binomial proportion.](@cite brown2001)
+  * [Pires and Amado (2008). Interval Estimators for a Binomial Proportion:
+     Comparison of Twenty Methods](@cite pires2008)
 
 # External links
 

--- a/src/clark_west.jl
+++ b/src/clark_west.jl
@@ -46,10 +46,10 @@ positive test statistic, for instance, above 1.645 for the 5% significance level
 
 Implements: [`pvalue`](@ref)
 # References
- * Clark, T. E., West, K. D. 2006, Using out-of-sample mean squared prediction errors to test
-   the martingale difference hypothesis. Journal of Econometrics, 135(1): 155–186.
- * Clark, T. E., West, K. D. 2007, Approximately normal tests for equal predictive accuracy
-   in nested models. Journal of Econometrics, 138(1): 291–311.
+ * [Clark and West (2006). Using Out-of-Sample Mean Squared Prediction Errors to Test the
+    Martingale Difference Hypothesis](@cite clark2006)
+ * [Clark and West (2007). Approximately Normal Tests for Equal Predictive Accuracy in
+    Nested Models](@cite clark2007)
 
 """
 function ClarkWestTest(e1::AbstractVector{<:Real}, e2::AbstractVector{<:Real},

--- a/src/correlation.jl
+++ b/src/correlation.jl
@@ -27,7 +27,7 @@ See also `partialcor` from StatsBase.
 * [Partial correlation on Wikipedia](https://en.wikipedia.org/wiki/Partial_correlation#As_conditional_independence_test)
   (for the construction of the confidence interval)
 * [Section testing using Student's t-distribution from Pearson correlation coefficient on Wikipedia](https://en.wikipedia.org/wiki/Pearson_correlation_coefficient#Testing_using_Student's_t-distribution)
-* [K.J. Levy and S.C. Narula (1978): Testing Hypotheses concerning Partial Correlations: Some Methods and Discussion. International Statistical Review 46(2).](https://www.jstor.org/stable/1402814)
+* [Levy and Narula (1978). Testing Hypotheses Concerning Partial Correlations: Some Methods and Discussion](@cite levy1978)
 """
 struct CorrelationTest{T<:Real} <: HypothesisTest
     r::T

--- a/src/diebold_mariano.jl
+++ b/src/diebold_mariano.jl
@@ -43,12 +43,11 @@ Economic Statistics, 13, 253-263. and `lookahead` is the number of steps ahead o
 
 # References
 
-  * Diebold, F.X. and Mariano, R.S. (1995) Comparing predictive accuracy. 
-    Journal of Business and Economic Statistics, 13, 253-263.
+  * [Diebold and Mariano (1995). Comparing predictive accuracy](@cite diebold1995)
 
-  * Harvey, D., Leybourne, S., & Newbold, P. (1997). Testing the equality of prediction 
-    mean squared errors. International Journal of forecasting, 13(2), 281-291.
-  
+  * [Harvey, Leybourne, and Newbold (1997). Testing the Equality of Prediction Mean Squared
+     Errors](@cite harvey1997)
+
 """
 function DieboldMarianoTest(e1::AbstractVector{<:Real}, e2::AbstractVector{<:Real}; 
                             loss::Function=abs2, lookahead::Integer=1)

--- a/src/durbin_watson.jl
+++ b/src/durbin_watson.jl
@@ -57,16 +57,12 @@ and `:right` (positive serial correlation).
 
 # References
 
-  * J. Durbin and G. S. Watson, 1951, "Testing for Serial Correlation in Least Squares
-    Regression: II", Biometrika, Vol. 38, No. 1/2, pp. 159-177,
-    [http://www.jstor.org/stable/2332325](http://www.jstor.org/stable/2332325).
-  * J. Durbin and G. S. Watson, 1950, "Testing for Serial Correlation in Least Squares
-    Regression: I", Biometrika, Vol. 37, No. 3/4, pp. 409-428,
-    [http://www.jstor.org/stable/2332391](http://www.jstor.org/stable/2332391).
-  * R. W. Farebrother, 1980, "Algorithm AS 153: Pan's Procedure for the Tail Probabilities
-    of the Durbin-Watson Statistic", Journal of the Royal Statistical Society, Series C
-    (Applied Statistics), Vol. 29, No. 2, pp. 224-227,
-    [http://www.jstor.org/stable/2986316](http://www.jstor.org/stable/2986316).
+  * [Durbin and Watson (1951). Testing for Serial Correlation in Least Squares Regression:
+     II](@cite durbin1951)
+  * [Durbin and Watson (1950). Testing for Serial Correlation in Least Squares Regression:
+     I](@cite durbin1950)
+  * [Farebrother (1980). Algorithm AS 153: Pan's Procedure for the Tail Probabilities of
+     the Durbin-Watson Statistic](@cite farebrother1980)
 
 # External links
 
@@ -103,13 +99,10 @@ elements in `a`, and `n` the number of approximation terms (see Farebrother, 198
 
 # References
 
-  * J. Durbin and G. S. Watson, 1971, "Testing for Serial Correlation in Least Squares
-  Regression: III", Biometrika, Vol. 58, No. 1, pp. 1-19,
-  [http://www.jstor.org/stable/2334313](http://www.jstor.org/stable/2334313).
-  * R. W. Farebrother, 1980, "Algorithm AS 153: Pan's Procedure for the Tail Probabilities
-  of the Durbin-Watson Statistic", Journal of the Royal Statistical Society, Series C
-  (Applied Statistics), Vol. 29, No. 2, pp. 224-227,
-  [http://www.jstor.org/stable/2986316](http://www.jstor.org/stable/2986316).
+  * [Durbin and Watson (1971). Testing for Serial Correlation in Least Squares Regression:
+     III](@cite durbin1971)
+  * [Farebrother (1980). Algorithm AS 153: Pan's Procedure for the Tail Probabilities of the
+     Durbin-Watson Statistic](@cite farebrother1980)
 
 """
 function pan_algorithm(a::AbstractArray, x::Float64, m::Int, n::Int)

--- a/src/f.jl
+++ b/src/f.jl
@@ -41,7 +41,7 @@ Implements: [`pvalue`](@ref)
 
 # References
 
-  * George E. P. Box, "Non-Normality and Tests on Variances", Biometrika 40 (3/4): 318–335, 1953.
+  * [Box (1953). Non-Normality and Tests on Variances](@cite box1953)
 
 # External links
 

--- a/src/fisher.jl
+++ b/src/fisher.jl
@@ -50,9 +50,8 @@ Implements: [`pvalue(::FisherExactTest)`](@ref), [`confint(::FisherExactTest)`](
 
 # References
 
-  * Fay, M.P., Supplementary material to "Confidence intervals that match Fisher’s exact or
-    Blaker’s exact tests". Biostatistics, Volume 11, Issue 2, 1 April 2010, Pages 373–374,
-    [link](https://doi.org/10.1093/biostatistics/kxp050)
+  * [Fay (2010). Confidence Intervals That Match Fisher's Exact or Blaker's
+     Exact Tests](@cite fay2010)
 """
 struct FisherExactTest <: HypothesisTest
     # Format:
@@ -114,11 +113,9 @@ For `tail = :both`, possible values for `method` are:
 
 # References
 
-  * Gibbons, J.D., Pratt, J.W., P-values: Interpretation and Methodology, American
-    Statistican, 29(1):20-25, 1975.
-  * Fay, M.P., Supplementary material to "Confidence intervals that match Fisher’s exact or
-    Blaker’s exact tests". Biostatistics, Volume 11, Issue 2, 1 April 2010, Pages 373–374,
-    [link](https://doi.org/10.1093/biostatistics/kxp050)
+  * [Gibbons and Pratt (1975). P-Values: Interpretation and Methodology](@cite gibbons1975)
+  * [Fay (2010). Confidence Intervals That Match Fisher's Exact or Blaker's
+     Exact Tests](@cite fay2010)
 """
 function StatsAPI.pvalue(x::FisherExactTest; tail=:both, method=:central)
     if tail == :both && method != :central
@@ -173,11 +170,9 @@ Fisher's non-central hypergeometric distribution. For `tail = :both`, the only
 
 # References
 
-  * Gibbons, J.D, Pratt, J.W. P-values: Interpretation and Methodology, American
-    Statistican, 29(1):20-25, 1975.
-  * Fay, M.P., Supplementary material to "Confidence intervals that match Fisher’s exact or
-    Blaker’s exact tests". Biostatistics, Volume 11, Issue 2, 1 April 2010, Pages 373–374,
-    [link](https://doi.org/10.1093/biostatistics/kxp050)
+  * [Gibbons and Pratt (1975). P-Values: Interpretation and Methodology](@cite gibbons1975)
+  * [Fay (2010). Confidence Intervals That Match Fisher's Exact or Blaker's
+     Exact Tests](@cite fay2010)
 """
 function StatsAPI.confint(x::FisherExactTest; level::Float64=0.95, tail=:both, method=:central)
     check_level(level)

--- a/src/jarque_bera.jl
+++ b/src/jarque_bera.jl
@@ -49,14 +49,10 @@ and medium sample sizes and it is a modification to the Jarque-Bera test (Urzua,
 
 # References
 
-  * Panagiotis Mantalos, 2011, "The three different measures of the sample skewness and
-    kurtosis and the effects to the Jarque-Bera test for normality", International Journal
-    of Computational Economics and Econometrics, Vol. 2, No. 1,
-    [link](http://dx.doi.org/10.1504/IJCEE.2011.040576).
+  * [Mantalos (2011). The three different measures of the sample skewness and
+     kurtosis and the effects to the Jarque-Bera test for normality](@cite mantalos2011)
 
-  * Carlos M. Urzúa, "On the correct use of omnibus tests for normality", Economics Letters,
-    Volume 53, Issue 3,
-    [link](https://doi.org/10.1016/S0165-1765(96)00923-8).
+  * [Urzúa (1996). On the Correct Use of Omnibus Tests for Normality](@cite urzua1996)
 
 # External links
 

--- a/src/kruskal_wallis.jl
+++ b/src/kruskal_wallis.jl
@@ -58,9 +58,9 @@ Implements: [`pvalue`](@ref)
 
 # References
 
-  * Meyer, J.P, Seaman, M.A., Expanded tables of critical values for the Kruskal-Wallis
-    H statistic. Paper presented at the annual meeting of the American Educational Research
-    Association, San Francisco, April 2006.
+  * [Meyer and Seaman (2008). Expanded Table of the Kruskal-Wallis Statistic](@cite meyer2008)
+  * [Meyer and Seaman (2013). A Comparison of the Exact Kruskal-Wallis Distribution to
+     Asymptotic Approximations for All Sample Sizes up to 105](@cite meyer2013)
 
 # External links
 

--- a/src/power_divergence.jl
+++ b/src/power_divergence.jl
@@ -58,14 +58,12 @@ one of the following methods. Possible values for `method` are:
 
 # References
 
-  * Agresti, Alan. Categorical Data Analysis, 3rd Edition. Wiley, 2013.
-  * Sison, C.P and Glaz, J. Simultaneous confidence intervals and sample size determination
-    for multinomial proportions. Journal of the American Statistical Association,
-    90:366-369, 1995.
-  * Quesensberry, C.P. and Hurst, D.C. Large Sample Simultaneous Confidence Intervals for
-    Multinational Proportions. Technometrics, 6:191-195, 1964.
-  * Gold, R. Z. Tests Auxiliary to ``χ^2`` Tests in a Markov Chain. Annals of
-    Mathematical Statistics, 30:56-74, 1963.
+  * [Agresti (2013). Categorical Data Analysis](@cite agresti2013)
+  * [Sison and Glaz (1995). Simultaneous Confidence Intervals and Sample Size Determination
+     for Multinomial Proportions](@cite sison1995)
+  * [Quesenberry and Hurst (1964). Large Sample Simultaneous Confidence Intervals for
+     Multinomial Proportions](@cite quesenberry1964)
+  * [Gold (1963). Tests Auxiliary to ``χ^2`` Tests in a Markov Chain](@cite gold1963)
 """
 function StatsAPI.confint(x::PowerDivergenceTest; level::Float64=0.95,
                           tail::Symbol=:both, method::Symbol=:auto, correct::Bool=true,
@@ -282,7 +280,7 @@ Implements: [`pvalue`](@ref), [`confint(::PowerDivergenceTest)`](@ref)
 
 # References
 
-  * Agresti, Alan. Categorical Data Analysis, 3rd Edition. Wiley, 2013.
+  * [Agresti (2013). Categorical Data Analysis](@cite agresti2013)
 """
 function PowerDivergenceTest(x::AbstractMatrix{T}; lambda::U=1.0, theta0::Vector{U} = ones(length(x))/length(x)) where {T<:Integer,U<:AbstractFloat}
 

--- a/src/shapiro_wilk.jl
+++ b/src/shapiro_wilk.jl
@@ -162,23 +162,14 @@ Implements: [`pvalue`](@ref)
   `sorted=true` keyword argument.
 
 # References
-Shapiro, S. S., & Wilk, M. B. (1965). An Analysis of Variance Test for Normality
-(Complete Samples). *Biometrika*, 52, 591–611.
-[doi:10.1093/BIOMET/52.3-4.591](https://doi.org/10.1093/BIOMET/52.3-4.591).
 
-Royston, P. (1992). Approximating the Shapiro-Wilk W-test for non-normality.
-*Statistics and Computing*, 2(3), 117–119.
-[doi:10.1007/BF01891203](https://doi.org/10.1007/BF01891203)
+* [Shapiro and Wilk (1965). An Analysis of Variance Test for Normality (Complete Samples)](@cite shapiro1965)
 
-Royston, P. (1993). A Toolkit for Testing for Non-Normality in Complete and
-Censored Samples. Journal of the Royal Statistical Society Series D
-(The Statistician), 42(1), 37–43.
-[doi:10.2307/2348109](https://doi.org/10.2307/2348109)
+* [Royston (1992). Approximating the Shapiro-Wilk W-test for Non-Normality](@cite royston1992)
 
-Royston, P. (1995). Remark AS R94: A Remark on Algorithm AS 181: The W-test for
-Normality. *Journal of the Royal Statistical Society Series C
-(Applied Statistics)*, 44(4), 547–551.
-[doi:10.2307/2986146](https://doi.org/10.2307/2986146).
+* [Royston (1993). A Toolkit for Testing for Non-Normality in Complete and Censored Samples](@cite royston1993)
+
+* [Royston (1995). Remark AS R94: A Remark on Algorithm AS 181: The W-test for Normality](@cite royston1995)
 """
 function ShapiroWilkTest(sample::AbstractVector{<:Real},
                          swcoefs::AbstractVector{<:Real}=shapiro_wilk_coefs(length(sample));

--- a/src/var_equality.jl
+++ b/src/var_equality.jl
@@ -134,10 +134,7 @@ Implements: [`pvalue`](@ref)
 
 # References
 
-  * Levene, Howard, "Robust tests for equality of variances".
-     In Ingram Olkin; Harold Hotelling; et al. (eds.).
-     Contributions to Probability and Statistics: Essays in Honor of Harold Hotelling.
-     Stanford University Press. pp. 278–292, 1960
+  * [Brown and Forsythe (1974). Robust Tests for the Equality of Variances](@cite brown1974)
 
 # External links
 
@@ -170,9 +167,7 @@ Implements: [`pvalue`](@ref)
 
 # References
 
-  * Brown, Morton B.; Forsythe, Alan B., "Robust tests for the equality of variances".
-    Journal of the American Statistical Association. 69: 364–367, 1974
-    doi:[10.1080/01621459.1974.10482955](https://doi.org/10.1080%2F01621459.1974.10482955).
+  * [Brown and Forsythe (1974). Robust Tests for the Equality of Variances](@cite brown1974)
 
 # External links
 
@@ -201,9 +196,8 @@ Implements: [`pvalue`](@ref)
 
 # References
 
-  * Conover, W. J., Johnson, M. E., Johnson, M. M., A comparative study of tests
-    for homogeneity of variances, with applications to the outer continental shelf bidding data.
-    Technometrics, 23, 351–361, 1980
+  * [Conover, Johnson, and Johnson (1981). A Comparative Study of Tests for Homogeneity of
+     Variances, with Applications to the Outer Continental Shelf Bidding Data](@cite conover1981)
 
 # External links
 

--- a/src/white.jl
+++ b/src/white.jl
@@ -51,9 +51,11 @@ test statistic is large enough.
 Implements: [`pvalue`](@ref)
 
 # References
-  * H. White, (1980): A heteroskedasticity-consistent covariance matrix estimator and a direct test for heteroskedasticity, Econometrica, 48, 817-838.
-  * T.S. Breusch & A.R. Pagan (1979), A simple test for heteroscedasticity and random coefficient variation, Econometrica, 47, 1287-1294
-  * R. Koenker (1981), A note on studentizing a test for heteroscedasticity, Journal of Econometrics, 17, 107-112
+  * [White (1980). A Heteroskedasticity-Consistent Covariance Matrix Estimator and a Direct
+     Test for Heteroskedasticity](@cite white1980)
+  * [Breusch and Pagan (1979). A Simple Test for Heteroscedasticity and
+     Random Coefficient Variation](@cite breusch1979)
+  * [Koenker (1981). A Note on Studentizing a Test for Heteroscedasticity](@cite koenker1981)
 
 # External links
   * [White's test on Wikipedia](https://en.wikipedia.org/wiki/White_test)


### PR DESCRIPTION
Moves citations in docstrings to a `@cite` link. Still keeps the author, year, and title for anyone viewing it from a REPL or such.