### PR TITLE
Signed rank and Mann-Whitney fixes: intervals, the two-sided p-value, and the documented nulls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,6 @@
 name = "HypothesisTests"
 uuid = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
-# Deliberately not 0.12.0 yet. This branch is breaking and 0.12.0 is what it will
-# be, but the bump lands with the stacked PR, so nothing between the two can be
-# registered by accident: 0.11.8 is already in General against a different hash,
-# so the registrator refuses it.
-version = "0.11.8"
+version = "0.12.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,7 +6,7 @@ HypothesisTests = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
 [compat]
 Documenter = "1"
 DocumenterCitations = "1"
-HypothesisTests = "0.11"
+HypothesisTests = "0.12"
 
 [sources]
 HypothesisTests = {path = ".."}

--- a/docs/src/nonparametric.md
+++ b/docs/src/nonparametric.md
@@ -86,7 +86,7 @@ hodgeslehmann
 The Hodges-Lehmann estimate is the point estimate the interval brackets, and is what all
 four types report as their parameter of interest. It is generally not the sample median:
 exact symmetry makes the two agree, but they can also agree by coincidence, as on
-`[0, 2, 2, 7]`, where both are `2`. Agreement is therefore no evidence of symmetry.
+`[1, 3, 3, 8]`, where both are `3`. Agreement is therefore no evidence of symmetry.
 
 Which order statistics `confint` returns depends on the test: the `Exact*` types invert
 the exact null distribution, conservatively, and the `Approximate*` types invert the
@@ -94,6 +94,12 @@ normal approximation with a continuity correction and a tie-corrected variance. 
 `Exact*` interval agrees with R's `wilcox.test` at `exact = TRUE` digit for digit; the
 `Approximate*` interval agrees with `exact = FALSE` to within one order statistic, since
 R solves for its endpoints numerically rather than reading them off the pairwise estimates.
+
+A one-sided interval keeps the endpoint that inverts the test of the same name:
+`tail = :left`, whose alternative is location below the null, gives an upper bound, and
+`tail = :right` a lower one. That is the convention of every other test here that takes a
+`tail`, and of R's `alternative = "less"` and `"greater"`. These four tests returned the
+other endpoint before this change (#368).
 
 Three named bounds apply, and past any of them the tests raise rather than run unbounded.
 The first bounds the tied-data enumeration a p-value runs, and `method = :approximate` is

--- a/docs/src/nonparametric.md
+++ b/docs/src/nonparametric.md
@@ -93,7 +93,7 @@ the exact null distribution, conservatively, and the `Approximate*` types invert
 normal approximation with a continuity correction and a tie-corrected variance. The
 `Exact*` interval agrees with R's `wilcox.test` at `exact = TRUE` digit for digit; the
 `Approximate*` interval agrees with `exact = FALSE` to within one order statistic, since
-R solves for its endpoints numerically rather than reading them off the contrast set.
+R solves for its endpoints numerically rather than reading them off the pairwise estimates.
 
 Three named bounds apply, and past any of them the tests raise rather than run unbounded.
 The first bounds the tied-data enumeration a p-value runs, and `method = :approximate` is

--- a/docs/src/nonparametric.md
+++ b/docs/src/nonparametric.md
@@ -90,8 +90,9 @@ exact symmetry makes the two agree, but they can also agree by coincidence, as o
 
 Which order statistics `confint` returns depends on the test: the `Exact*` types invert
 the exact null distribution, conservatively, and the `Approximate*` types invert the
-normal approximation with a continuity correction and a tie-corrected variance. The
-`Exact*` interval agrees with R's `wilcox.test` at `exact = TRUE` digit for digit; the
+normal approximation with a continuity correction and a tie-corrected variance. On untied
+data the `Exact*` interval agrees with R's `wilcox.test` at `exact = TRUE` digit for digit,
+and under ties R declines an exact interval even when asked for one; the
 `Approximate*` interval agrees with `exact = FALSE` to within one order statistic, since
 R solves for its endpoints numerically rather than reading them off the pairwise estimates.
 

--- a/docs/src/nonparametric.md
+++ b/docs/src/nonparametric.md
@@ -107,8 +107,9 @@ The first bounds the tied-data enumeration a p-value runs, and `method = :approx
 the way past it. The second bounds the set of pairwise estimates, which `confint` and
 `hodgeslehmann` form whichever route the p-value took, so `method` is no help there; it is a
 bound on memory, which is all the approximate interval spends. The third bounds the exact
-interval, which spends time as well, a lattice recursion for every candidate endpoint it
-considers, and so is bounded far below the second.
+Mann-Whitney interval, which spends time as well, a two-sample lattice recursion per
+bisection step, and so is bounded below the second; the exact signed rank interval bisects
+a cheaper recursion and meets only the second.
 
 All three raise `ComputationTooLarge`, which is its own type rather than an `ArgumentError`
 so that `show` can drop a refused interval line without also hiding real errors.

--- a/docs/src/nonparametric.md
+++ b/docs/src/nonparametric.md
@@ -83,10 +83,17 @@ and `hodgeslehmann` returns its median.
 hodgeslehmann
 ```
 
-The Hodges-Lehmann estimate is the point estimate the interval brackets. It is generally
-not the sample median: exact symmetry makes the two agree, but they can also agree by
-coincidence, as on `[0, 2, 2, 7]`, where both are `2`. Agreement is therefore no evidence
-of symmetry.
+The Hodges-Lehmann estimate is the point estimate the interval brackets, and is what all
+four types report as their parameter of interest. It is generally not the sample median:
+exact symmetry makes the two agree, but they can also agree by coincidence, as on
+`[0, 2, 2, 7]`, where both are `2`. Agreement is therefore no evidence of symmetry.
+
+Which order statistics `confint` returns depends on the test: the `Exact*` types invert
+the exact null distribution, conservatively, and the `Approximate*` types invert the
+normal approximation with a continuity correction and a tie-corrected variance. The
+`Exact*` interval agrees with R's `wilcox.test` at `exact = TRUE` digit for digit; the
+`Approximate*` interval agrees with `exact = FALSE` to within one order statistic, since
+R solves for its endpoints numerically rather than reading them off the contrast set.
 
 Three named bounds apply, and past any of them the tests raise rather than run unbounded.
 The first bounds the tied-data enumeration a p-value runs, and `method = :approximate` is

--- a/src/HypothesisTests.jl
+++ b/src/HypothesisTests.jl
@@ -102,7 +102,7 @@ function Base.show(_io::IO, test::T) where T<:HypothesisTest
     params = show_or_nothing(population_param_of_interest, test)
     println(io, "Population details:")
     if params === nothing
-        println(io, "    parameter of interest:   not computed for a sample this size")
+        println(io, "    parameter of interest:   not computed (over MAX_PAIRWISE_ESTIMATES)")
     else
         (param_name, param_under_h0, param_estimate) = params
         println(io, "    parameter of interest:   $param_name")

--- a/src/HypothesisTests.jl
+++ b/src/HypothesisTests.jl
@@ -69,26 +69,27 @@ end
 
 Base.showerror(io::IO, err::ComputationTooLarge) = print(io, "ComputationTooLarge: ", err.msg)
 
-# The interval `show` prints beside the point estimate, or `nothing` where there is none
-# to print. A test whose `confint` refuses the sample it was given still has a name, a
-# statistic and a p-value worth displaying, so the offending line is dropped rather than
-# the whole display: the rank tests bound the pairwise estimates their intervals are read
-# off (see `MAX_PAIRWISE_ESTIMATES`), and past that bound a large `MannWhitneyUTest` would
-# otherwise be impossible to look at.
+# `show` asks a test for two things it may not be able to give for the sample it was
+# handed: its point estimate and its interval. For the rank tests both are read off a
+# pairwise set bounded by `MAX_PAIRWISE_ESTIMATES`, so past that bound each raises. A
+# test that cannot afford one still has a name, a statistic and a p-value worth seeing,
+# so what cannot be computed is dropped rather than the whole display.
 #
-# Only `ComputationTooLarge` is caught. `confint` is generic over `HypothesisTest`, so
-# catching `ArgumentError` here would also swallow a genuine argument bug in any
-# downstream package's `confint` method and print a test with no interval line instead of
-# raising, which is a hard thing to debug.
-function show_confint(test::HypothesisTest)
-    applicable(confint, test) || return nothing
+# Only `ComputationTooLarge` is caught. These functions are generic over
+# `HypothesisTest`, so catching `ArgumentError` here would also swallow a genuine
+# argument bug in any downstream package's method and print a test with a line missing
+# instead of raising, which is a hard thing to debug.
+function show_or_nothing(f, test::HypothesisTest)
     try
-        return confint(test)
+        return f(test)
     catch err
         err isa ComputationTooLarge || rethrow()
         return nothing
     end
 end
+
+show_confint(test::HypothesisTest) =
+    applicable(confint, test) ? show_or_nothing(confint, test) : nothing
 
 # Pretty-print
 function Base.show(_io::IO, test::T) where T<:HypothesisTest
@@ -98,15 +99,20 @@ function Base.show(_io::IO, test::T) where T<:HypothesisTest
 
     # population details
     ci = show_confint(test)
-    (param_name, param_under_h0, param_estimate) = population_param_of_interest(test)
+    params = show_or_nothing(population_param_of_interest, test)
     println(io, "Population details:")
-    println(io, "    parameter of interest:   $param_name")
-    print(io, "    value under h_0:         ")
-    show(io, param_under_h0)
-    println(io)
-    print(io, "    point estimate:          ")
-    show(io, param_estimate)
-    println(io)
+    if params === nothing
+        println(io, "    parameter of interest:   not computed for a sample this size")
+    else
+        (param_name, param_under_h0, param_estimate) = params
+        println(io, "    parameter of interest:   $param_name")
+        print(io, "    value under h_0:         ")
+        show(io, param_under_h0)
+        println(io)
+        print(io, "    point estimate:          ")
+        show(io, param_estimate)
+        println(io)
+    end
 
     if ci !== nothing
         print(io, "    95% confidence interval: ")

--- a/src/common.jl
+++ b/src/common.jl
@@ -45,7 +45,8 @@ function tiedrank_adj!(ord::AbstractVector, v::AbstractArray)
         if j > i
             t = j - i + 1
             m = sum(i:j) / t
-            tieadj += t^3 - t
+            # in Int128: t^3 wraps Int64 for a tie group of 2^21 or more equal values
+            tieadj += Int128(t)^3 - t
             for k = i:j
                 ord[place[k]] = m
             end

--- a/src/mann_whitney.jl
+++ b/src/mann_whitney.jl
@@ -127,10 +127,7 @@ ExactMannWhitneyUTest(x::AbstractVector{S}, y::AbstractVector{T}) where {S<:Real
     ExactMannWhitneyUTest(mwustats(x, y)...)
 
 testname(::ExactMannWhitneyUTest) = "Exact Mann-Whitney U test"
-# Still the difference of sample medians, not the Hodges-Lehmann estimate the label
-# names and `confint` is built around. Changing it moves a number users see, so it
-# waits for the breaking pull request. See #363.
-population_param_of_interest(x::ExactMannWhitneyUTest) = ("Location parameter (pseudomedian)", 0, x.median) # parameter of interest: name, value under h0, point estimate
+population_param_of_interest(x::ExactMannWhitneyUTest) = ("Location parameter (pseudomedian)", 0, hodgeslehmann(x)) # parameter of interest: name, value under h0, point estimate
 default_tail(test::ExactMannWhitneyUTest) = :both
 
 function show_params(io::IO, x::ExactMannWhitneyUTest, ident)
@@ -274,10 +271,7 @@ ApproximateMannWhitneyUTest(x::AbstractVector{S}, y::AbstractVector{T}) where {S
     ApproximateMannWhitneyUTest(mwustats(x, y)...)
 
 testname(::ApproximateMannWhitneyUTest) = "Approximate Mann-Whitney U test"
-# Still the difference of sample medians, not the Hodges-Lehmann estimate the label
-# names and `confint` is built around. Changing it moves a number users see, so it
-# waits for the breaking pull request. See #363.
-population_param_of_interest(x::ApproximateMannWhitneyUTest) = ("Location parameter (pseudomedian)", 0, x.median) # parameter of interest: name, value under h0, point estimate
+population_param_of_interest(x::ApproximateMannWhitneyUTest) = ("Location parameter (pseudomedian)", 0, hodgeslehmann(x)) # parameter of interest: name, value under h0, point estimate
 default_tail(test::ApproximateMannWhitneyUTest) = :both
 
 function show_params(io::IO, x::ApproximateMannWhitneyUTest, ident)

--- a/src/mann_whitney.jl
+++ b/src/mann_whitney.jl
@@ -131,7 +131,7 @@ ExactMannWhitneyUTest(x::AbstractVector{S}, y::AbstractVector{T}) where {S<:Real
     ExactMannWhitneyUTest(mwustats(x, y)...)
 
 testname(::ExactMannWhitneyUTest) = "Exact Mann-Whitney U test"
-population_param_of_interest(x::ExactMannWhitneyUTest) = ("Location parameter (pseudomedian)", 0, hodgeslehmann(x)) # parameter of interest: name, value under h0, point estimate
+population_param_of_interest(x::ExactMannWhitneyUTest) = ("Location shift", 0, hodgeslehmann(x)) # parameter of interest: name, value under h0, point estimate
 default_tail(test::ExactMannWhitneyUTest) = :both
 
 function show_params(io::IO, x::ExactMannWhitneyUTest, ident)
@@ -275,7 +275,7 @@ ApproximateMannWhitneyUTest(x::AbstractVector{S}, y::AbstractVector{T}) where {S
     ApproximateMannWhitneyUTest(mwustats(x, y)...)
 
 testname(::ApproximateMannWhitneyUTest) = "Approximate Mann-Whitney U test"
-population_param_of_interest(x::ApproximateMannWhitneyUTest) = ("Location parameter (pseudomedian)", 0, hodgeslehmann(x)) # parameter of interest: name, value under h0, point estimate
+population_param_of_interest(x::ApproximateMannWhitneyUTest) = ("Location shift", 0, hodgeslehmann(x)) # parameter of interest: name, value under h0, point estimate
 default_tail(test::ApproximateMannWhitneyUTest) = :both
 
 function show_params(io::IO, x::ApproximateMannWhitneyUTest, ident)

--- a/src/mann_whitney.jl
+++ b/src/mann_whitney.jl
@@ -120,7 +120,7 @@ See [`MannWhitneyUTest`](@ref) on what that null does and does not assume.
 
 When there are no tied ranks, the exact p-value is computed using the `wilcoxcdf` and `wilcoxccdf`
 functions from the `StatsFuns` package. In the presence of tied ranks, a p-value is computed by exhaustive
-enumeration of permutations, which can be very slow for even moderately sized data sets.
+enumeration of the assignments of the pooled midranks to the smaller sample.
 
 The tied route is bounded by [`MAX_EXACT_ENUMERATION_N`](@ref): beyond it this test
 refuses rather than enumerate indefinitely, and `method = :approximate` is the way on.
@@ -243,16 +243,19 @@ from the same distribution, against the alternative that one tends to exceed the
 See [`MannWhitneyUTest`](@ref) on what that null does and does not assume.
 
 The p-value is computed using a normal approximation to the distribution of the
-Mann-Whitney U statistic:
+Mann-Whitney U statistic, which under the null has mean and variance
 ```math
     \\begin{align*}
-        μ & = \\frac{n_x n_y}{2}\\\\
+        μ_0 & = \\frac{n_x n_y}{2}\\\\
         σ^2 & = \\frac{n_x n_y}{12}\\left(n_x + n_y + 1 - \\frac{a}{(n_x + n_y)(n_x +
             n_y - 1)}\\right)\\\\
         a & = \\sum_{t \\in \\mathcal{T}} t^3 - t
     \\end{align*}
 ```
 where ``\\mathcal{T}`` is the set of the counts of tied values at each tied position.
+What `show` reports as `normal approximation (μ, σ)` is the pair ``(U - μ_0, σ)``: the
+statistic centred at its null mean, and the tie-corrected standard deviation, not ``μ_0``
+itself.
 
 The confidence interval inverts the same approximation, rather than the exact null
 distribution.

--- a/src/mann_whitney.jl
+++ b/src/mann_whitney.jl
@@ -46,9 +46,9 @@ Under a shift model the location estimated is the median of `x - y`, reported by
 
 The Mann-Whitney U test is sometimes known as the Wilcoxon rank-sum test.
 
-When there are no tied ranks and ≤50 samples, or tied ranks and ≤10 samples,
-`MannWhitneyUTest` performs an exact Mann-Whitney U test. In all other cases,
-`MannWhitneyUTest` performs an approximate Mann-Whitney U test.
+`MannWhitneyUTest` chooses between the exact and the approximate test by the tie pattern and
+the pooled sample size `nx + ny`: with no tied ranks it is exact for `nx + ny ≤ 50`, with tied
+ranks for `nx + ny ≤ 10`, and approximate above whichever of those two applies.
 
 `method` overrides that choice:
 

--- a/src/mann_whitney.jl
+++ b/src/mann_whitney.jl
@@ -38,8 +38,9 @@ Equality of the two distributions is what makes the test exact: it renders the p
 observations exchangeable, which is what the null distribution of the statistic rests on.
 This is *not* a test of `P(x > y) = P(y > x)` alone. That weaker equality permits the two
 distributions to differ in spread, and then the test does not hold its level: for
-`Normal(0, 1)` against `Normal(0, 9)`, where it holds exactly, a nominal 0.05 test rejects
-about 13% of the time at `nx, ny = 30, 10`, and about 1.6% at `10, 30`.
+`Normal(0, 1)` against `Normal(0, 3)` (σ = 3, so three times the spread), where it holds
+exactly, a nominal 0.05 test rejects about 13% of the time at `nx, ny = 30, 10`, and about
+1.7% at `10, 30`.
 
 Under a shift model the location estimated is the median of `x - y`, reported by
 [`hodgeslehmann`](@ref).

--- a/src/mann_whitney.jl
+++ b/src/mann_whitney.jl
@@ -217,7 +217,7 @@ function StatsAPI.confint(x::ExactMannWhitneyUTest; level::Real=0.95, tail=:both
         "Pass `method = :approximate` for the normal-approximation interval, which " *
         "inverts a closed form and is bounded by memory alone.")
     vals = cross_differences(x.x, x.y)
-    k = exact_ci_index(length(vals), alpha, u -> wilcoxcdf(x.nx, x.ny, u))
+    k = exact_ci_index(length(vals), alpha, u -> wilcoxcdf(x.nx, x.ny, u); tail = tail)
     return ci_from_estimates(vals, k, tail)
 end
 
@@ -308,6 +308,6 @@ function StatsAPI.confint(x::ApproximateMannWhitneyUTest; level::Real=0.95, tail
     alpha = ci_alpha(level, tail)
     vals = cross_differences(x.x, x.y)
     m = length(vals)
-    k = normal_ci_index(m, m / 2, x.sigma, alpha)
+    k = normal_ci_index(m, m / 2, x.sigma, alpha; tail = tail)
     return ci_from_estimates(vals, k, tail)
 end

--- a/src/mann_whitney.jl
+++ b/src/mann_whitney.jl
@@ -30,12 +30,19 @@ export MannWhitneyUTest, ExactMannWhitneyUTest, ApproximateMannWhitneyUTest
 """
     MannWhitneyUTest(x::AbstractVector{<:Real}, y::AbstractVector{<:Real}; method = :auto)
 
-Perform a Mann-Whitney U test of the null hypothesis that the probability that an
-observation drawn from the same population as `x` is greater than an observation drawn
-from the same population as `y` is equal to the probability that an observation drawn
-from the same population as `y` is greater than an observation drawn from the same
-population as `x` against the alternative hypothesis that these probabilities are not
-equal.
+Perform a Mann-Whitney U test of the null hypothesis that `x` and `y`
+are drawn from the same distribution, against the alternative that one tends to exceed
+the other.
+
+Equality of the two distributions is what makes the test exact: it renders the pooled
+observations exchangeable, which is what the null distribution of the statistic rests on.
+This is *not* a test of `P(x > y) = P(y > x)` alone. That weaker equality permits the two
+distributions to differ in spread, and then the test does not hold its level: for
+`Normal(0, 1)` against `Normal(0, 9)`, where it holds exactly, a nominal 0.05 test rejects
+about 13% of the time at `nx, ny = 30, 10`, and about 1.6% at `10, 30`.
+
+Under a shift model the location estimated is the median of `x - y`, reported by
+[`hodgeslehmann`](@ref).
 
 The Mann-Whitney U test is sometimes known as the Wilcoxon rank-sum test.
 
@@ -107,12 +114,9 @@ end
 """
     ExactMannWhitneyUTest(x::AbstractVector{<:Real}, y::AbstractVector{<:Real})
 
-Perform an exact Mann-Whitney U test of the null hypothesis that the probability that an
-observation drawn from the same population as `x` is greater than an observation drawn
-from the same population as `y` is equal to the probability that an observation drawn
-from the same population as `y` is greater than an observation drawn from the same
-population as `x` against the alternative hypothesis that these probabilities are not
-equal.
+Perform an exact Mann-Whitney U test of the null hypothesis that `x` and `y` are drawn
+from the same distribution, against the alternative that one tends to exceed the other.
+See [`MannWhitneyUTest`](@ref) on what that null does and does not assume.
 
 When there are no tied ranks, the exact p-value is computed using the `wilcoxcdf` and `wilcoxccdf`
 functions from the `StatsFuns` package. In the presence of tied ranks, a p-value is computed by exhaustive
@@ -234,19 +238,16 @@ end
 """
     ApproximateMannWhitneyUTest(x::AbstractVector{<:Real}, y::AbstractVector{<:Real})
 
-Perform an approximate Mann-Whitney U test of the null hypothesis that the probability that
-an observation drawn from the same population as `x` is greater than an observation drawn
-from the same population as `y` is equal to the probability that an observation drawn
-from the same population as `y` is greater than an observation drawn from the same
-population as `x` against the alternative hypothesis that these probabilities are not
-equal.
+Perform an approximate Mann-Whitney U test of the null hypothesis that `x` and `y` are drawn
+from the same distribution, against the alternative that one tends to exceed the other.
+See [`MannWhitneyUTest`](@ref) on what that null does and does not assume.
 
 The p-value is computed using a normal approximation to the distribution of the
 Mann-Whitney U statistic:
 ```math
     \\begin{align*}
         μ & = \\frac{n_x n_y}{2}\\\\
-        σ & = \\frac{n_x n_y}{12}\\left(n_x + n_y + 1 - \\frac{a}{(n_x + n_y)(n_x +
+        σ^2 & = \\frac{n_x n_y}{12}\\left(n_x + n_y + 1 - \\frac{a}{(n_x + n_y)(n_x +
             n_y - 1)}\\right)\\\\
         a & = \\sum_{t \\in \\mathcal{T}} t^3 - t
     \\end{align*}

--- a/src/rank_common.jl
+++ b/src/rank_common.jl
@@ -238,7 +238,10 @@ Small samples cannot reach every level: the widest interval this form admits,
 `k = 0`, has coverage `1 - 2 cdf(0)`, which is `1 - 2^(1-n)` for an untied signed rank
 sample, so `0.95` is out of reach below `n = 6` and `0.99` below `n = 8`. That interval
 is still the best available and is returned, with a warning naming the coverage it
-actually has, rather than being returned as though it met the request. R warns here too.
+actually has, rather than being returned as though it met the request. R returns the same
+interval, but silently: its `conf.level` attribute still claims the level that was asked
+for, and it warns only once the shortfall exceeds `alpha/2`, as at two observations
+against two.
 
 `tail` only shapes that warning: `alpha` is already the two-sided mass whichever tail
 the interval keeps, but the level a one-sided caller asked for is `1 - alpha/2`, not
@@ -326,8 +329,10 @@ end
 # stands for is location *below* the null, and what is compatible with that is an upper
 # bound. Eight of the nine other `confint` methods here that take a `tail` do the same, as
 # does R's `wilcox.test` under `alternative = "less"`. These four returned the other
-# endpoint until #368. `SignTest` is the ninth and still returns a lower bound, capped at
-# the null rather than infinite; that is the same defect and is filed separately.
+# endpoint until #368. `SignTest` is the ninth and is wrong twice over, both out of scope
+# here: it still returns a lower bound for `:left`, which is this same defect (#372), and
+# it caps the far side at the hypothesised median rather than leaving it infinite, so its
+# interval moves when the null moves (#369).
 function ci_from_estimates(vals::AbstractVector, k::Integer, tail::Symbol)
     m = length(vals)
     left = vals[k + 1]

--- a/src/rank_common.jl
+++ b/src/rank_common.jl
@@ -229,9 +229,24 @@ at most `k`.
 
 This is the rule R's `wilcox.test` uses, where the lower endpoint is
 `diffs[qsignrank(alpha/2, n)]`; taking `k = qsignrank(alpha/2, n) - 1` reproduces it.
+
+Small samples cannot reach every level: the widest interval this form admits,
+`k = 0`, has coverage `1 - 2 cdf(0)`, which is `1 - 2^(1-n)` for an untied signed rank
+sample, so `0.95` is out of reach below `n = 6` and `0.99` below `n = 8`. That interval
+is still the best available and is returned, with a warning naming the coverage it
+actually has, rather than being returned as though it met the request. R warns here too.
 """
 function exact_ci_index(m::Integer, alpha::Real, cdf)
     half = alpha / 2
+    p0 = cdf(0)
+    if p0 >= half
+        # `1 - 2 p0` double-counts the atom at 0 when the null distribution is degenerate,
+        # so it can come out negative; the coverage is nowhere below zero.
+        @warn "the requested confidence level is not attainable for a sample this small; " *
+              "returning the widest interval this construction admits" requested = 1 - alpha attainable =
+              max(0.0, 1 - 2 * p0)
+        return 0
+    end
     return last_true(div(m, 2), k -> cdf(k) < half)
 end
 
@@ -260,10 +275,23 @@ designs: at `level = 0.90` that happens for 131 of the 1444 Mann-Whitney shapes 
 there rather than this one that is loose, and coverage stays at nominal rather than
 falling below it: at `(3, 12)`, `(3, 15)` and `(3, 21)` the normal route covers `0.902`,
 `0.901` and `0.900` against the exact route's `0.932`, `0.927` and `0.919`.
+
+A negative `k` means the approximation puts the endpoint outside the contrast set, so the
+widest interval available is returned instead, with a warning. The warning does not claim
+the level is unattainable, because that does not follow: at `n = 8` and `level = 0.99` this
+rule asks for `k = -1` while the exact route reaches `0.9922`, which meets the request.
+What it does mean is that the sample is too small for this route, and `method = :exact` is
+where to go.
 """
 function normal_ci_index(m::Integer, mu::Real, sigma::Real, alpha::Real)
     q = quantile(Normal(mu, sigma), alpha / 2)
-    return clamp(ceil(Int, q - one(q) / 2) - 1, 0, div(m, 2))
+    k = ceil(Int, q - one(q) / 2) - 1
+    if k < 0
+        @warn "the normal approximation puts the interval endpoint outside the contrast " *
+              "set for a sample this small; returning the widest interval it admits, " *
+              "which may not reach the requested level. The exact test is the way on" requested = 1 - alpha
+    end
+    return clamp(k, 0, div(m, 2))
 end
 
 # `level`/`tail` to the two-sided alpha the index rules work in. A one-sided bound

--- a/src/rank_common.jl
+++ b/src/rank_common.jl
@@ -307,6 +307,11 @@ function ci_alpha(level::Real, tail::Symbol)
     return tail === :both ? 1 - lev : 2 * (1 - lev)
 end
 
+# A one-sided interval keeps the endpoint that inverts the test of the same name, which is
+# the opposite endpoint to the one the tail is named after: the alternative `tail = :left`
+# stands for is location *below* the null, and what is compatible with that is an upper
+# bound. Every other test here that takes a `tail` does the same, as does R's `wilcox.test`
+# under `alternative = "less"`. These four returned the other endpoint until #368.
 function ci_from_estimates(vals::AbstractVector, k::Integer, tail::Symbol)
     m = length(vals)
     left = vals[k + 1]
@@ -314,9 +319,9 @@ function ci_from_estimates(vals::AbstractVector, k::Integer, tail::Symbol)
     if tail === :both
         return (left, right)
     elseif tail === :left
-        return (left, oftype(left, Inf))
-    else # tail === :right
         return (oftype(right, -Inf), right)
+    else # tail === :right
+        return (left, oftype(left, Inf))
     end
 end
 

--- a/src/rank_common.jl
+++ b/src/rank_common.jl
@@ -320,8 +320,10 @@ end
 # A one-sided interval keeps the endpoint that inverts the test of the same name, which is
 # the opposite endpoint to the one the tail is named after: the alternative `tail = :left`
 # stands for is location *below* the null, and what is compatible with that is an upper
-# bound. Every other test here that takes a `tail` does the same, as does R's `wilcox.test`
-# under `alternative = "less"`. These four returned the other endpoint until #368.
+# bound. Eight of the nine other `confint` methods here that take a `tail` do the same, as
+# does R's `wilcox.test` under `alternative = "less"`. These four returned the other
+# endpoint until #368. `SignTest` is the ninth and still returns a lower bound, capped at
+# the null rather than infinite; that is the same defect and is filed separately.
 function ci_from_estimates(vals::AbstractVector, k::Integer, tail::Symbol)
     m = length(vals)
     left = vals[k + 1]

--- a/src/rank_common.jl
+++ b/src/rank_common.jl
@@ -282,12 +282,13 @@ default. Dropping it makes the interval narrower than the exact one for 7 of 66 
 rank sample sizes at `level = 0.95` and 45 of 66 at `level = 0.90`; with it the interval
 is never narrower than exact at `level = 0.95` or above.
 
-Below that it can still be narrower by one order statistic, on strongly unbalanced
-designs: at `level = 0.90` that happens for 131 of the 1444 Mann-Whitney shapes with
-`nx, ny` in `3:40`, concentrated at `nx = 3`. It is the exact rule that is conservative
-there rather than this one that is loose, and coverage stays at nominal rather than
-falling below it: at `(3, 12)`, `(3, 15)` and `(3, 21)` the normal route covers `0.902`,
-`0.901` and `0.900` against the exact route's `0.932`, `0.927` and `0.919`.
+Below that it can still be narrower by one order statistic, in both procedures: at
+`level = 0.90` that happens for 10 of the 66 signed rank sizes `n = 5:70`, and for 131 of
+the 1444 Mann-Whitney shapes with `nx, ny` in `3:40`, where it concentrates on strongly
+unbalanced designs at `nx = 3`. It is the exact rule that is conservative there rather
+than this one that is loose, and coverage stays at nominal rather than falling below it:
+at `(3, 12)`, `(3, 15)` and `(3, 21)` the normal route covers `0.902`, `0.901` and
+`0.900` against the exact route's `0.932`, `0.927` and `0.919`.
 
 A negative `k` means the approximation puts the endpoint outside the pairwise estimates, so
 the widest interval available is returned instead, with a warning. The warning does not

--- a/src/rank_common.jl
+++ b/src/rank_common.jl
@@ -115,9 +115,10 @@ See #7 and #97.
 
 The bound is on memory alone, which is what the approximate routes spend: forming this many
 estimates costs about 8 MB, and sorting them about that again. It admits a signed rank
-sample of roughly 1400 observations and a two-sample design of 1000 against 1000. The exact
-routes spend time as well, and are bounded far below this by
-[`MAX_EXACT_CI_ESTIMATES`](@ref).
+sample of roughly 1400 observations and a two-sample design of 1000 against 1000. The
+two-sample exact interval spends time as well and carries its own bound below this,
+[`MAX_EXACT_CI_ESTIMATES`](@ref); the one-sample exact interval bisects cheaply enough
+that this bound is the only one it meets, about 6 s at the boundary.
 """
 const MAX_PAIRWISE_ESTIMATES = 1_000_000
 
@@ -130,28 +131,31 @@ function check_estimate_count(m::Integer, what::AbstractString)
 end
 
 """
-Largest set of pairwise estimates whose *exact* interval will be inverted.
+Largest set of pairwise estimates whose *exact* Mann-Whitney interval will be inverted.
 
-Selecting an endpoint from the exact null distribution costs a lattice recursion for every
-candidate it considers, so this route spends time where the approximate one spends only the
-memory [`MAX_PAIRWISE_ESTIMATES`](@ref) bounds, and it needs a bound of its own, far below.
-Past this one the exact interval is refused; the approximate interval, where the test has
-one, is not.
+Selecting an endpoint from the exact null distribution runs a lattice recursion per
+bisection step, and the two-sample recursion (`wilcoxcdf`) is the expensive one: at this
+bound, a 300-against-300 design, the interval takes about 11 s, from 0.6 s at 158 against
+158, and it grows steeply past it, 35 s at 400 against 400. Past it the exact interval is
+refused; the approximate interval, which inverts a closed form, is not.
 
-Sized by the slower of the two procedures. The signed rank interval scans every candidate,
-``m/2`` recursions, and at the bound, a sample of 223, takes about 9 s; the two-sample
-interval bisects instead, about ``\\log_2(m/2)`` of them, and takes under a second at the
-same point. The scan grows steeply past it: a signed rank sample of 250 takes 16 s, one of
-300 takes 39 s, and one of 400 does not finish.
+The one-sample recursion (`signrankcdf`) is cheap enough that the signed rank interval
+carries no time bound at all: it reaches the memory bound
+[`MAX_PAIRWISE_ESTIMATES`](@ref), a sample of 1413, in about 6 s.
+
+The number was first 25\\_000, sized against the ``m/2``-recursion endpoint scan that
+inverted the signed rank interval before #361; the bisection that replaced the scan
+moved the cost from the one-sample route to the two-sample one, and the same wall-clock
+ceiling, re-measured, sits at 90\\_000.
 """
-const MAX_EXACT_CI_ESTIMATES = 25_000
+const MAX_EXACT_CI_ESTIMATES = 90_000
 
 function check_exact_ci_cost(m::Integer, escape::AbstractString)
     m <= MAX_EXACT_CI_ESTIMATES && return nothing
     throw(ComputationTooLarge(
         "refusing to invert the exact null distribution over $m pairwise estimates: more " *
-        "than MAX_EXACT_CI_ESTIMATES = $MAX_EXACT_CI_ESTIMATES. Choosing an endpoint costs " *
-        "a lattice recursion per candidate, so this route is bounded well below " *
+        "than MAX_EXACT_CI_ESTIMATES = $MAX_EXACT_CI_ESTIMATES. Choosing an endpoint runs " *
+        "a two-sample lattice recursion per bisection step, so this route is bounded below " *
         "MAX_PAIRWISE_ESTIMATES = $MAX_PAIRWISE_ESTIMATES, which bounds memory alone. " *
         escape))
 end

--- a/src/rank_common.jl
+++ b/src/rank_common.jl
@@ -276,9 +276,9 @@ there rather than this one that is loose, and coverage stays at nominal rather t
 falling below it: at `(3, 12)`, `(3, 15)` and `(3, 21)` the normal route covers `0.902`,
 `0.901` and `0.900` against the exact route's `0.932`, `0.927` and `0.919`.
 
-A negative `k` means the approximation puts the endpoint outside the contrast set, so the
-widest interval available is returned instead, with a warning. The warning does not claim
-the level is unattainable, because that does not follow: at `n = 8` and `level = 0.99` this
+A negative `k` means the approximation puts the endpoint outside the pairwise estimates, so
+the widest interval available is returned instead, with a warning. The warning does not
+claim the level is unattainable, because that does not follow: at `n = 8` and `level = 0.99` this
 rule asks for `k = -1` while the exact route reaches `0.9922`, which meets the request.
 What it does mean is that the sample is too small for this route, and `method = :exact` is
 where to go.
@@ -287,9 +287,10 @@ function normal_ci_index(m::Integer, mu::Real, sigma::Real, alpha::Real)
     q = quantile(Normal(mu, sigma), alpha / 2)
     k = ceil(Int, q - one(q) / 2) - 1
     if k < 0
-        @warn "the normal approximation puts the interval endpoint outside the contrast " *
-              "set for a sample this small; returning the widest interval it admits, " *
-              "which may not reach the requested level. The exact test is the way on" requested = 1 - alpha
+        @warn "the normal approximation puts the interval endpoint outside the set of " *
+              "pairwise estimates for a sample this small; returning the widest interval " *
+              "it admits, which may not reach the requested level. The exact test is " *
+              "the way on" requested = 1 - alpha
     end
     return clamp(k, 0, div(m, 2))
 end

--- a/src/rank_common.jl
+++ b/src/rank_common.jl
@@ -221,7 +221,7 @@ function last_true(H::Integer, pred)
 end
 
 """
-    exact_ci_index(m, alpha, cdf) -> Int
+    exact_ci_index(m, alpha, cdf; tail = :both) -> Int
 
 Invert the exact null distribution conservatively: the largest `k` whose interval
 still attains at least `1 - alpha`. `cdf(k)` is the null probability of a statistic
@@ -235,23 +235,29 @@ Small samples cannot reach every level: the widest interval this form admits,
 sample, so `0.95` is out of reach below `n = 6` and `0.99` below `n = 8`. That interval
 is still the best available and is returned, with a warning naming the coverage it
 actually has, rather than being returned as though it met the request. R warns here too.
+
+`tail` only shapes that warning: `alpha` is already the two-sided mass whichever tail
+the interval keeps, but the level a one-sided caller asked for is `1 - alpha/2`, not
+`1 - alpha`, and the coverage its single overshooting tail costs is `cdf(0)` once,
+not twice.
 """
-function exact_ci_index(m::Integer, alpha::Real, cdf)
+function exact_ci_index(m::Integer, alpha::Real, cdf; tail::Symbol = :both)
     half = alpha / 2
     p0 = cdf(0)
-    if p0 >= half
+    if p0 > half
         # `1 - 2 p0` double-counts the atom at 0 when the null distribution is degenerate,
         # so it can come out negative; the coverage is nowhere below zero.
+        sides = tail === :both ? 2 : 1
         @warn "the requested confidence level is not attainable for a sample this small; " *
-              "returning the widest interval this construction admits" requested = 1 - alpha attainable =
-              max(0.0, 1 - 2 * p0)
+              "returning the widest interval this construction admits" requested = 1 - sides * half attainable =
+              max(0.0, 1 - sides * p0)
         return 0
     end
-    return last_true(div(m, 2), k -> cdf(k) < half)
+    return last_true(div(m - 1, 2), k -> cdf(k) < half)
 end
 
 """
-    normal_ci_index(m, mu, sigma, alpha) -> Int
+    normal_ci_index(m, mu, sigma, alpha; tail = :both) -> Int
 
 Invert the normal approximation to the null distribution, `mu` and `sigma` being its
 mean and (tie-corrected) standard deviation.
@@ -282,17 +288,21 @@ claim the level is unattainable, because that does not follow: at `n = 8` and `l
 rule asks for `k = -1` while the exact route reaches `0.9922`, which meets the request.
 What it does mean is that the sample is too small for this route, and `method = :exact` is
 where to go.
+
+As in [`exact_ci_index`](@ref), `tail` only shapes the warning: a one-sided caller asked
+for level `1 - alpha/2`, and that is what the warning should name as the request.
 """
-function normal_ci_index(m::Integer, mu::Real, sigma::Real, alpha::Real)
+function normal_ci_index(m::Integer, mu::Real, sigma::Real, alpha::Real; tail::Symbol = :both)
     q = quantile(Normal(mu, sigma), alpha / 2)
     k = ceil(Int, q - one(q) / 2) - 1
     if k < 0
+        sides = tail === :both ? 2 : 1
         @warn "the normal approximation puts the interval endpoint outside the set of " *
               "pairwise estimates for a sample this small; returning the widest interval " *
               "it admits, which may not reach the requested level. The exact test is " *
-              "the way on" requested = 1 - alpha
+              "the way on" requested = 1 - sides * (alpha / 2)
     end
-    return clamp(k, 0, div(m, 2))
+    return clamp(k, 0, div(m - 1, 2))
 end
 
 # `level`/`tail` to the two-sided alpha the index rules work in. A one-sided bound

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -33,15 +33,17 @@ export SignedRankTest, ExactSignedRankTest, ApproximateSignedRankTest
 
 Perform a Wilcoxon signed rank test of the null hypothesis that the distribution of `x`
 (or the difference `x - y` if `y` is provided) is symmetric about zero, against the
-alternative that it is symmetric about some other location.
+alternative that it is not. Under a location model, where the distribution is symmetric about
+some `θ`, that is `θ = 0` against `θ ≠ 0`, with `tail = :left` and `tail = :right` giving
+`θ < 0` and `θ > 0`.
 
 Symmetry is what the test needs, not a zero median: against a null of zero median alone it
 does not hold its level. The location it estimates is the pseudomedian (see
 [`hodgeslehmann`](@ref)), which equals the median when the distribution is symmetric.
 
-When there are no tied ranks and ≤50 samples, or tied ranks and ≤15 samples,
-`SignedRankTest` performs an exact signed rank test. In all other cases,
-`SignedRankTest` performs an approximate signed rank test.
+`SignedRankTest` chooses between the exact and the approximate test by the tie pattern and
+the number `n` of non-zero observations: with no tied ranks it is exact for `n ≤ 50`, with
+tied ranks for `n ≤ 15`, and approximate above whichever of those two applies.
 
 `method` overrides that choice:
 
@@ -103,8 +105,8 @@ end
 
 Perform an exact Wilcoxon signed rank test of the null hypothesis that the distribution of
 `x` (or the difference `x - y` if `y` is provided) is symmetric about zero, against the
-alternative that it is symmetric about some other location. See [`SignedRankTest`](@ref) on
-what that null does and does not assume.
+alternative that it is not. See [`SignedRankTest`](@ref) on what that null does and does not
+assume, and on the alternatives the `tail` keyword selects.
 
 When there are no tied ranks, the exact p-value is computed using the `signrankcdf` and `signrankccdf`
 functions from the `StatsFuns` package. In the presence of tied ranks, a p-value is computed by exhaustive
@@ -242,7 +244,7 @@ end
 
 Perform an approximate Wilcoxon signed rank test of the null hypothesis that the
 distribution of `x` (or the difference `x - y` if `y` is provided) is symmetric about zero,
-against the alternative that it is symmetric about some other location. See
+against the alternative that it is not. See
 [`SignedRankTest`](@ref) on what that null does and does not assume.
 
 The p-value is computed using a normal approximation to the distribution of the signed rank

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -218,12 +218,12 @@ hodgeslehmann(x::ExactSignedRankTest) = median(signedrank_pairwise_estimates(x.v
 function StatsAPI.confint(x::ExactSignedRankTest; level::Real=0.95, tail=:both)
     alpha = ci_alpha(level, tail)
     n = length(x.ranks)
+    # No time bound here, where the scan this bisection replaced carried
+    # MAX_EXACT_CI_ESTIMATES: `signrankcdf` per step is cheap enough that the memory
+    # bound inside `walsh_averages` is the one this route meets, about 6 s in total at
+    # its boundary, a sample of 1413. The two-sample route runs `wilcoxcdf` instead,
+    # which is the expensive recursion, and keeps that bound.
     vals = signedrank_pairwise_estimates(x.vals)
-    # this route still inverts the exact distribution, a lattice recursion per candidate
-    # endpoint, so it keeps the bound the scan it replaces was given
-    check_exact_ci_cost(length(vals),
-        "Pass `method = :approximate` for the normal-approximation interval, which " *
-        "inverts a closed form and is bounded by memory alone.")
     k = exact_ci_index(length(vals), alpha, i -> signrankcdf(n, i); tail = tail)
     return ci_from_estimates(vals, k, tail)
 end

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -93,8 +93,8 @@ end
 
 struct ExactSignedRankTest <: HypothesisTest
     vals::Vector{Float64}   # original values
-    W::Float64              # test statistic: Wilcoxon rank-sum statistic
-    ranks::Vector{Float64}           # ranks without ties (zero values)
+    W::Float64              # test statistic: the signed rank statistic W+
+    ranks::Vector{Float64}           # midranks of |d| over the non-zero observations
     signs::BitArray{1}      # signs of input of ranks
     tie_adjustment::Float64 # adjustment for ties
     n::Int                  # number of observations
@@ -110,7 +110,7 @@ assume, and on the alternatives the `tail` keyword selects.
 
 When there are no tied ranks, the exact p-value is computed using the `signrankcdf` and `signrankccdf`
 functions from the `StatsFuns` package. In the presence of tied ranks, a p-value is computed by exhaustive
-enumeration of permutations, which can be very slow for even moderately sized data sets.
+enumeration of the ``2^n`` sign assignments over the non-zero observations.
 
 The tied route is bounded by [`MAX_EXACT_ENUMERATION_N`](@ref): beyond it this test
 refuses rather than enumerate indefinitely, and `method = :approximate` is the way on.
@@ -230,8 +230,8 @@ end
 
 struct ApproximateSignedRankTest <: HypothesisTest
     vals::Vector{Float64}   # original values
-    W::Float64              # test statistic: Wilcoxon rank-sum statistic
-    ranks::Vector{Float64} # ranks without ties (zero values)
+    W::Float64              # test statistic: the signed rank statistic W+
+    ranks::Vector{Float64} # midranks of |d| over the non-zero observations
     signs::BitArray{1}      # signs of input of ranks
     tie_adjustment::Float64 # adjustment for ties
     n::Int                  # number of observations
@@ -248,15 +248,18 @@ against the alternative that it is not. See
 [`SignedRankTest`](@ref) on what that null does and does not assume.
 
 The p-value is computed using a normal approximation to the distribution of the signed rank
-statistic:
+statistic ``W^+``, which under the null has mean and variance
 ```math
     \\begin{align*}
-        μ & = \\frac{n(n + 1)}{4}\\\\
+        μ_0 & = \\frac{n(n + 1)}{4}\\\\
         σ^2 & = \\frac{n(n + 1)(2n + 1)}{24} - \\frac{a}{48}\\\\
         a & = \\sum_{t \\in \\mathcal{T}} t^3 - t
     \\end{align*}
 ```
-where ``\\mathcal{T}`` is the set of the counts of tied values at each tied position.
+where ``\\mathcal{T}`` is the set of the counts of tied values at each tied position and
+``n`` counts the non-zero observations. What `show` reports as `normal approximation (μ, σ)`
+is the pair ``(W^+ - μ_0, σ)``: the statistic centred at its null mean, and the
+tie-corrected standard deviation, not ``μ_0`` itself.
 
 The confidence interval inverts the same approximation, rather than the exact null
 distribution.

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -250,7 +250,7 @@ statistic:
 ```math
     \\begin{align*}
         μ & = \\frac{n(n + 1)}{4}\\\\
-        σ & = \\frac{n(n + 1)(2 * n + 1)}{24} - \\frac{a}{48}\\\\
+        σ^2 & = \\frac{n(n + 1)(2n + 1)}{24} - \\frac{a}{48}\\\\
         a & = \\sum_{t \\in \\mathcal{T}} t^3 - t
     \\end{align*}
 ```

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -161,11 +161,13 @@ function StatsAPI.pvalue(x::ExactSignedRankTest; tail=:both)
     elseif x.tie_adjustment == 0
         # Compute exact p-value using method from StatsFuns, which is fast but cannot account for ties
         if tail == :both
-            if x.W <= n * (n + 1)/4
-                2 * signrankcdf(n, x.W)
-            else
-                2 * signrankccdf(n, x.W - 1)
-            end
+            # The smaller tail, doubled and clipped. Doubling a discrete tail can
+            # overshoot: where n(n+1)/2 is even the null mean is attainable, and at
+            # W == n(n+1)/4 each tail is (1 + P(W == mean))/2, so the doubling gives
+            # 1 + P(W == mean), which is 1.25 for n = 3 at W = 3. The tied branch below
+            # and both exact Mann-Whitney branches clip for the same reason.
+            p = x.W <= n * (n + 1)/4 ? signrankcdf(n, x.W) : signrankccdf(n, x.W - 1)
+            min(2 * p, 1.0)
         elseif tail == :left
             signrankcdf(n, x.W)
         else

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -126,6 +126,7 @@ default_tail(test::ExactSignedRankTest) = :both
 
 function show_params(io::IO, x::ExactSignedRankTest, ident)
     println(io, ident, "number of observations:      ", x.n)
+    println(io, ident, "non-zero observations:       ", length(x.ranks))
     println(io, ident, "Wilcoxon rank-sum statistic: ", x.W)
     print(io, ident, "rank sums:                   ")
     show(io, [sum(x.ranks[x.signs]), sum(x.ranks[map(!, x.signs)])])
@@ -277,6 +278,7 @@ default_tail(test::ApproximateSignedRankTest) = :both
 
 function show_params(io::IO, x::ApproximateSignedRankTest, ident)
     println(io, ident, "number of observations:      ", x.n)
+    println(io, ident, "non-zero observations:       ", length(x.ranks))
     println(io, ident, "Wilcoxon rank-sum statistic: ", x.W)
     print(io, ident, "rank sums:                   ")
     show(io, [sum(x.ranks[x.signs]), sum(x.ranks[map(!, x.signs)])])

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -130,13 +130,13 @@ population_param_of_interest(x::ExactSignedRankTest) = ("Location parameter (pse
 default_tail(test::ExactSignedRankTest) = :both
 
 function show_params(io::IO, x::ExactSignedRankTest, ident)
-    println(io, ident, "number of observations:      ", x.n)
-    println(io, ident, "non-zero observations:       ", length(x.ranks))
-    println(io, ident, "Wilcoxon rank-sum statistic: ", x.W)
-    print(io, ident, "rank sums:                   ")
+    println(io, ident, "number of observations:         ", x.n)
+    println(io, ident, "non-zero observations:          ", length(x.ranks))
+    println(io, ident, "Wilcoxon signed rank statistic: ", x.W)
+    print(io, ident, "rank sums:                      ")
     show(io, [sum(x.ranks[x.signs]), sum(x.ranks[map(!, x.signs)])])
     println(io)
-    println(io, ident, "adjustment for ties:         ", x.tie_adjustment)
+    println(io, ident, "adjustment for ties:            ", x.tie_adjustment)
 end
 
 # Enumerate all possible Wilcoxon rank-sum results for a given vector, determining left-
@@ -288,14 +288,14 @@ population_param_of_interest(x::ApproximateSignedRankTest) = ("Location paramete
 default_tail(test::ApproximateSignedRankTest) = :both
 
 function show_params(io::IO, x::ApproximateSignedRankTest, ident)
-    println(io, ident, "number of observations:      ", x.n)
-    println(io, ident, "non-zero observations:       ", length(x.ranks))
-    println(io, ident, "Wilcoxon rank-sum statistic: ", x.W)
-    print(io, ident, "rank sums:                   ")
+    println(io, ident, "number of observations:         ", x.n)
+    println(io, ident, "non-zero observations:          ", length(x.ranks))
+    println(io, ident, "Wilcoxon signed rank statistic: ", x.W)
+    print(io, ident, "rank sums:                      ")
     show(io, [sum(x.ranks[x.signs]), sum(x.ranks[map(!, x.signs)])])
     println(io)
-    println(io, ident, "adjustment for ties:         ", x.tie_adjustment)
-    println(io, ident, "normal approximation (μ, σ): ", (x.mu, x.sigma))
+    println(io, ident, "adjustment for ties:            ", x.tie_adjustment)
+    println(io, ident, "normal approximation (μ, σ):    ", (x.mu, x.sigma))
 end
 
 function StatsAPI.pvalue(x::ApproximateSignedRankTest; tail=:both)

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -59,7 +59,8 @@ Equivalently, construct [`ExactSignedRankTest`](@ref) or
 Implements: [`pvalue`](@ref), [`confint`](@ref), [`hodgeslehmann`](@ref)
 """
 function SignedRankTest(x::AbstractVector{T}; method = :auto) where T<:Real
-    (W, ranks, signs, tie_adjustment, n, median) = signedrankstats(x)
+    v = convert(Vector{T}, x)
+    (W, ranks, signs, tie_adjustment, n, median) = signedrankstats(v)
     # `ranks` covers the non-zero observations alone, so its length is that count
     n_nonzero = length(ranks)
     # the named tuple the `method` callable is documented to receive, and the automatic
@@ -68,9 +69,9 @@ function SignedRankTest(x::AbstractVector{T}; method = :auto) where T<:Real
              tie_adjustment = tie_adjustment)
     default = n_nonzero <= 15 || (n_nonzero <= 50 && tie_adjustment == 0) ? :exact : :approximate
     if resolve_rank_method(method, stats, default) === :exact
-        ExactSignedRankTest(x, W, ranks, signs, tie_adjustment, n, median)
+        ExactSignedRankTest(v, W, ranks, signs, tie_adjustment, n, median)
     else
-        ApproximateSignedRankTest(x, W, ranks, signs, tie_adjustment, n, median)
+        ApproximateSignedRankTest(v, W, ranks, signs, tie_adjustment, n, median)
     end
 end
 SignedRankTest(x::AbstractVector{T}, y::AbstractVector{S}; method = :auto) where {T<:Real,S<:Real} =
@@ -117,8 +118,10 @@ refuses rather than enumerate indefinitely, and `method = :approximate` is the w
 
 Implements: [`pvalue`](@ref), [`confint`](@ref), [`hodgeslehmann`](@ref)
 """
-ExactSignedRankTest(x::AbstractVector{T}) where {T<:Real} =
-    ExactSignedRankTest(x, signedrankstats(x)...)
+function ExactSignedRankTest(x::AbstractVector{T}) where {T<:Real}
+    v = convert(Vector{T}, x)
+    return ExactSignedRankTest(v, signedrankstats(v)...)
+end
 ExactSignedRankTest(x::AbstractVector{S}, y::AbstractVector{T}) where {S<:Real,T<:Real} =
     ExactSignedRankTest(x - y)
 
@@ -221,7 +224,7 @@ function StatsAPI.confint(x::ExactSignedRankTest; level::Real=0.95, tail=:both)
     check_exact_ci_cost(length(vals),
         "Pass `method = :approximate` for the normal-approximation interval, which " *
         "inverts a closed form and is bounded by memory alone.")
-    k = exact_ci_index(length(vals), alpha, i -> signrankcdf(n, i))
+    k = exact_ci_index(length(vals), alpha, i -> signrankcdf(n, i); tail = tail)
     return ci_from_estimates(vals, k, tail)
 end
 
@@ -269,11 +272,14 @@ Implements: [`pvalue`](@ref), [`confint`](@ref), [`hodgeslehmann`](@ref)
 function ApproximateSignedRankTest(x::Vector, W::Float64, ranks::Vector{T}, signs::BitArray{1}, tie_adjustment::Float64, n::Int, median::Real) where T<:Real
     nz = length(ranks) # num non-zeros
     mu = W - nz * (nz + 1)/4
-    std = sqrt(nz * (nz + 1) * (2 * nz + 1) / 24 - tie_adjustment / 48)
+    # the triple product in Int128: in Int64 it wraps from nz = 2^21, silently
+    std = sqrt(Int128(nz) * (nz + 1) * (2 * nz + 1) / 24 - tie_adjustment / 48)
     ApproximateSignedRankTest(x, W, ranks, signs, tie_adjustment, n, median, mu, std)
 end
-ApproximateSignedRankTest(x::AbstractVector{T}) where {T<:Real} =
-    ApproximateSignedRankTest(x, signedrankstats(x)...)
+function ApproximateSignedRankTest(x::AbstractVector{T}) where {T<:Real}
+    v = convert(Vector{T}, x)
+    return ApproximateSignedRankTest(v, signedrankstats(v)...)
+end
 ApproximateSignedRankTest(x::AbstractVector{S}, y::AbstractVector{T}) where {S<:Real,T<:Real} =
     ApproximateSignedRankTest(x - y)
 
@@ -315,6 +321,6 @@ function StatsAPI.confint(x::ApproximateSignedRankTest; level::Real=0.95, tail=:
     alpha = ci_alpha(level, tail)
     vals = signedrank_pairwise_estimates(x.vals)
     m = length(vals)
-    k = normal_ci_index(m, m / 2, x.sigma, alpha)
+    k = normal_ci_index(m, m / 2, x.sigma, alpha; tail = tail)
     return ci_from_estimates(vals, k, tail)
 end

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -116,9 +116,7 @@ ExactSignedRankTest(x::AbstractVector{S}, y::AbstractVector{T}) where {S<:Real,T
     ExactSignedRankTest(x - y)
 
 testname(::ExactSignedRankTest) = "Exact Wilcoxon signed rank test"
-# Still the sample median, not the Hodges-Lehmann estimate the label names and the
-# interval is built around. See #363.
-population_param_of_interest(x::ExactSignedRankTest) = ("Location parameter (pseudomedian)", 0, x.median) # parameter of interest: name, value under h0, point estimate
+population_param_of_interest(x::ExactSignedRankTest) = ("Location parameter (pseudomedian)", 0, hodgeslehmann(x)) # parameter of interest: name, value under h0, point estimate
 default_tail(test::ExactSignedRankTest) = :both
 
 function show_params(io::IO, x::ExactSignedRankTest, ident)
@@ -185,15 +183,11 @@ function StatsAPI.pvalue(x::ExactSignedRankTest; tail=:both)
     end
 end
 
-# The Walsh averages that the point estimate is read off.
+# The Walsh averages that the interval and the point estimate are read off.
 #
 # `signedrankstats` drops zero differences before ranking, so the statistic and the
-# p-value describe the non-zero differences, and the estimate must describe the same
-# sample. R's `wilcox.test` drops them likewise.
-#
-# `confint` does not yet use this: it still forms its Walsh averages from every
-# difference, zeros included, so the interval and the estimate can describe
-# different samples. See #362.
+# p-value describe the non-zero differences; the interval and the estimate must
+# describe the same sample. R's `wilcox.test` drops them likewise.
 function signedrank_pairwise_estimates(vals::AbstractVector{<:Real})
     nonzero = filter(!iszero, vals)
     # every difference is zero: nothing to drop, and the pairwise estimates degenerate to
@@ -203,8 +197,23 @@ end
 
 hodgeslehmann(x::ExactSignedRankTest) = median(signedrank_pairwise_estimates(x.vals))
 
-StatsAPI.confint(x::ExactSignedRankTest; level::Real=0.95, tail=:both) =
-    calculate_ci(x.vals, level, tail=tail)
+# Ties are a caveat here rather than a correction: under ties the null distribution of
+# the statistic is no longer the untied one this inverts, so the achieved coverage is
+# approximate. (R declines to compute an exact interval at all in that case and falls
+# back to the normal approximation, which on the samples tested lands on the same order
+# statistics.) `ApproximateSignedRankTest` does account for ties, through its variance.
+function StatsAPI.confint(x::ExactSignedRankTest; level::Real=0.95, tail=:both)
+    alpha = ci_alpha(level, tail)
+    n = length(x.ranks)
+    vals = signedrank_pairwise_estimates(x.vals)
+    # this route still inverts the exact distribution, a lattice recursion per candidate
+    # endpoint, so it keeps the bound the scan it replaces was given
+    check_exact_ci_cost(length(vals),
+        "Pass `method = :approximate` for the normal-approximation interval, which " *
+        "inverts a closed form and is bounded by memory alone.")
+    k = exact_ci_index(length(vals), alpha, i -> signrankcdf(n, i))
+    return ci_from_estimates(vals, k, tail)
+end
 
 
 ## APPROXIMATE SIGNED RANK TEST
@@ -238,8 +247,8 @@ statistic:
 ```
 where ``\\mathcal{T}`` is the set of the counts of tied values at each tied position.
 
-The confidence interval still inverts the exact null distribution, whichever route the
-p-value took (see #361).
+The confidence interval inverts the same approximation, rather than the exact null
+distribution.
 
 Implements: [`pvalue`](@ref), [`confint`](@ref), [`hodgeslehmann`](@ref)
 """
@@ -255,9 +264,7 @@ ApproximateSignedRankTest(x::AbstractVector{S}, y::AbstractVector{T}) where {S<:
     ApproximateSignedRankTest(x - y)
 
 testname(::ApproximateSignedRankTest) = "Approximate Wilcoxon signed rank test"
-# Still the sample median, not the Hodges-Lehmann estimate the label names and the
-# interval is built around. See #363.
-population_param_of_interest(x::ApproximateSignedRankTest) = ("Location parameter (pseudomedian)", 0, x.median) # parameter of interest: name, value under h0, point estimate
+population_param_of_interest(x::ApproximateSignedRankTest) = ("Location parameter (pseudomedian)", 0, hodgeslehmann(x)) # parameter of interest: name, value under h0, point estimate
 default_tail(test::ApproximateSignedRankTest) = :both
 
 function show_params(io::IO, x::ApproximateSignedRankTest, ident)
@@ -286,40 +293,13 @@ end
 
 hodgeslehmann(x::ApproximateSignedRankTest) = median(signedrank_pairwise_estimates(x.vals))
 
-# Still the exact interval, on both signed rank types: `calculate_ci` inverts the
-# exact null distribution whichever test it was called on, so selecting the
-# approximate test does not yet produce an approximate interval, and the tie
-# correction this type carries in `sigma` does not reach the interval. See #361.
-StatsAPI.confint(x::ApproximateSignedRankTest; level::Real=0.95, tail=:both) =
-    calculate_ci(x.vals, level, tail=tail)
-
-# implementation method inspired by these notes: http://www.stat.umn.edu/geyer/old03/5102/notes/rank.pdf
-function calculate_ci(x::AbstractVector, level::Real=0.95; tail=:both)
-    # `Float64` for the same reason as in `ci_alpha`: `check_level` is `Float64`-only
-    level = Float64(level)
-    check_level(level)
-    check_tail(tail)
-
-    if tail == :both
-        c = level
-    else
-        c = 1 - 2 * (1-level)
-    end
-    n = length(x)
-    m = div(n * (n + 1), 2)
-    check_estimate_count(m, "Walsh averages")
-    # and bound the k scan below, which runs m/2 lattice recursions and so becomes
-    # unusable at a sample size far short of what materialising the set costs. Both
-    # signed rank types arrive here, since neither has an approximate interval yet.
-    check_exact_ci_cost(m,
-        "Both signed rank tests invert the exact distribution for their interval " *
-        "whichever route their p-value took, so `method` does not reach this (see #361).")
-    k_range = 1:div(m, 2)
-    # A single observation has a single Walsh average, so the only interval is that
-    # point and there is no k to choose between. The scan below was handed the empty
-    # range 1:0 and `argmin` refused it. R's `wilcox.test` returns the point here too.
-    isempty(k_range) && return ci_from_estimates(walsh_averages(x), 0, tail)
-    l = [1 - 2 * signrankcdf(n, i) for i in k_range]
-    k = argmin(abs.(l .- c))
-    return ci_from_estimates(walsh_averages(x), k, tail)
+# The exact null distribution is not consulted here: an approximate test gets an
+# approximate interval, from the same normal approximation (mean, and variance
+# corrected for ties) that its p-value uses.
+function StatsAPI.confint(x::ApproximateSignedRankTest; level::Real=0.95, tail=:both)
+    alpha = ci_alpha(level, tail)
+    vals = signedrank_pairwise_estimates(x.vals)
+    m = length(vals)
+    k = normal_ci_index(m, m / 2, x.sigma, alpha)
+    return ci_from_estimates(vals, k, tail)
 end

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -32,8 +32,12 @@ export SignedRankTest, ExactSignedRankTest, ApproximateSignedRankTest
     SignedRankTest(x::AbstractVector{<:Real}, y::AbstractVector{<:Real}; method = :auto)
 
 Perform a Wilcoxon signed rank test of the null hypothesis that the distribution of `x`
-(or the difference `x - y` if `y` is provided) has zero median against the alternative
-hypothesis that the median is non-zero.
+(or the difference `x - y` if `y` is provided) is symmetric about zero, against the
+alternative that it is symmetric about some other location.
+
+Symmetry is what the test needs, not a zero median: against a null of zero median alone it
+does not hold its level. The location it estimates is the pseudomedian (see
+[`hodgeslehmann`](@ref)), which equals the median when the distribution is symmetric.
 
 When there are no tied ranks and ≤50 samples, or tied ranks and ≤15 samples,
 `SignedRankTest` performs an exact signed rank test. In all other cases,
@@ -97,9 +101,10 @@ end
 """
     ExactSignedRankTest(x::AbstractVector{<:Real}[, y::AbstractVector{<:Real}])
 
-Perform a Wilcoxon exact signed rank U test of the null hypothesis that the distribution of
-`x` (or the difference `x - y` if `y` is provided) has zero median against the alternative
-hypothesis that the median is non-zero.
+Perform an exact Wilcoxon signed rank test of the null hypothesis that the distribution of
+`x` (or the difference `x - y` if `y` is provided) is symmetric about zero, against the
+alternative that it is symmetric about some other location. See [`SignedRankTest`](@ref) on
+what that null does and does not assume.
 
 When there are no tied ranks, the exact p-value is computed using the `signrankcdf` and `signrankccdf`
 functions from the `StatsFuns` package. In the presence of tied ranks, a p-value is computed by exhaustive
@@ -234,9 +239,10 @@ end
 """
     ApproximateSignedRankTest(x::AbstractVector{<:Real}[, y::AbstractVector{<:Real}])
 
-Perform a Wilcoxon approximate signed rank U test of the null hypothesis that the
-distribution of `x` (or the difference `x - y` if `y` is provided) has zero median against
-the alternative hypothesis that the median is non-zero.
+Perform an approximate Wilcoxon signed rank test of the null hypothesis that the
+distribution of `x` (or the difference `x - y` if `y` is provided) is symmetric about zero,
+against the alternative that it is symmetric about some other location. See
+[`SignedRankTest`](@ref) on what that null does and does not assume.
 
 The p-value is computed using a normal approximation to the distribution of the signed rank
 statistic:

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -382,10 +382,15 @@ end
     t = MannWhitneyUTest(collect(1.0:nx), collect(1.5:1:(ny + 0.5)))
     @test nx * ny > HypothesisTests.MAX_PAIRWISE_ESTIMATES
     @test_throws HypothesisTests.ComputationTooLarge confint(t)
+    # #363 made the reported estimate the Hodges-Lehmann one, read off the same set,
+    # so past the bound the point estimate goes the same way the interval does
+    @test_throws HypothesisTests.ComputationTooLarge hodgeslehmann(t)
     out = sprint(show, t)
     @test occursin("Approximate Mann-Whitney U test", out)
     @test occursin("two-sided p-value", out)
+    @test occursin("number of observations in each group", out)
     @test !occursin("confidence interval", out)
+    @test !occursin("point estimate", out)
 
     # and where it can afford one it still prints it
     @test occursin("95% confidence interval",
@@ -440,8 +445,9 @@ end
                 @test lo_a == -hi_b
                 @test hi_a == -lo_b
             end
-            # and a lower bound becomes the negated upper bound
-            @test confint(a; tail=:left)[1] == -confint(b; tail=:right)[2]
+            # compare the finite ends: under the #368 convention `:left` is an upper
+            # bound and `:right` a lower one, so `[1]` on both would be -Inf either way
+            @test confint(a; tail=:left)[2] == -confint(b; tail=:right)[1]
         end
     end
 end

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -450,8 +450,13 @@ end
             @test pvalue(a; tail=:left) == pvalue(b; tail=:right)
             # the two-sided interval reflects about zero, ends exchanged
             for level in (0.90, 0.95, 0.99)
-                lo_a, hi_a = confint(a; level=level)
-                lo_b, hi_b = confint(b; level=level)
+                # the smaller designs here cannot attain the higher levels, so both
+                # routes warn. That behaviour is pinned in "Unattainable levels warn"
+                # in test/wilcoxon.jl; here it is noise over the reflection identity.
+                (lo_a, hi_a), (lo_b, hi_b) =
+                    Base.CoreLogging.with_logger(Base.CoreLogging.NullLogger()) do
+                        confint(a; level=level), confint(b; level=level)
+                    end
                 @test lo_a == -hi_b
                 @test hi_a == -lo_b
             end

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -234,9 +234,14 @@ end
     @test population_param_of_interest(ta)[3] == hodgeslehmann(ta)
     @test population_param_of_interest(ta)[3] != median(a) - median(b)
 
-    # one-sided bounds
-    @test confint(ExactMannWhitneyUTest(x, y); tail=:left)[2] == Inf
-    @test confint(ExactMannWhitneyUTest(x, y); tail=:right)[1] == -Inf
+    # one-sided bounds, on the same convention as every other test here and as R: the
+    # alternative :left names is a shift below zero, which an upper bound is compatible
+    # with (#368)
+    @test confint(ExactMannWhitneyUTest(x, y); tail=:left)[1] == -Inf
+    @test confint(ExactMannWhitneyUTest(x, y); tail=:right)[2] == Inf
+    lo, hi = confint(ExactMannWhitneyUTest(x, y))
+    @test confint(ExactMannWhitneyUTest(x, y); tail=:left)[2] <= hi
+    @test confint(ExactMannWhitneyUTest(x, y); tail=:right)[1] >= lo
 
     # a narrower interval for a lower confidence level
     lo95, hi95 = confint(ExactMannWhitneyUTest(x, y); level=0.95)

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -236,12 +236,45 @@ end
 
     # one-sided bounds, on the same convention as every other test here and as R: the
     # alternative :left names is a shift below zero, which an upper bound is compatible
-    # with (#368)
-    @test confint(ExactMannWhitneyUTest(x, y); tail=:left)[1] == -Inf
-    @test confint(ExactMannWhitneyUTest(x, y); tail=:right)[2] == Inf
+    # with (#368). R: wilcox.test(x, y, conf.int = TRUE, alternative = "less") ->
+    # (-Inf, -1.1), "greater" -> (-10.1, Inf)
+    @test all(isapprox.(confint(ExactMannWhitneyUTest(x, y); tail=:left), (-Inf, -1.1); atol=1e-8))
+    @test all(isapprox.(confint(ExactMannWhitneyUTest(x, y); tail=:right), (-10.1, Inf); atol=1e-8))
     lo, hi = confint(ExactMannWhitneyUTest(x, y))
     @test confint(ExactMannWhitneyUTest(x, y); tail=:left)[2] <= hi
     @test confint(ExactMannWhitneyUTest(x, y); tail=:right)[1] >= lo
+    # R: conf.level = 0.90 -> (-10.1, -1.1)
+    @test all(isapprox.(confint(ExactMannWhitneyUTest(x, y); level=0.90), (-10.1, -1.1); atol=1e-8))
+
+    # the approximate route on the same untied sample. R with exact = FALSE,
+    # correct = TRUE: p = 0.02574808082, interval (-11.09998, -0.10008) solved
+    # numerically beside the order statistics returned here, "less" -> (-Inf, -1.10004),
+    # "greater" -> (-10.09992, Inf)
+    ma = ApproximateMannWhitneyUTest(Float64.(x), Float64.(y))
+    @test isapprox(pvalue(ma), 0.02574808082, atol=1e-9)
+    @test all(isapprox.(confint(ma), (-11.1, -0.1); atol=1e-3))
+    @test all(isapprox.(confint(ma; tail=:left), (-Inf, -1.1); atol=1e-3))
+    @test all(isapprox.(confint(ma; tail=:right), (-10.1, Inf); atol=1e-3))
+
+    # tied one-sided p-values against exactRankTests::wilcox.exact, which computes the
+    # same conditional distribution: "less" -> 0.0060017382, "greater" -> 0.9949199407.
+    # One-sided values are convention-free. The two-sided ones differ: doubling here
+    # (0.0120034764) against summing the far tail there (0.0118890398), and the tied
+    # two-sample conditional distribution is asymmetric, so the two need not agree.
+    tt = ExactMannWhitneyUTest([1:10;], [2:2:24;])
+    @test isapprox(pvalue(tt; tail=:left), 0.0060017382, atol=1e-9)
+    @test isapprox(pvalue(tt; tail=:right), 0.9949199407, atol=1e-9)
+    @test pvalue(tt) == 2 * pvalue(tt; tail=:left)
+
+    # tied approximate one-sided intervals: R (approximate route, uniroot) gives
+    # (-Inf, -2.000005) and (-13.0, Inf); the order statistics land there too
+    tta = ApproximateMannWhitneyUTest(Float64.([1:10;]), Float64.([2:2:24;]))
+    @test all(isapprox.(confint(tta; tail=:left), (-Inf, -2.0); atol=1e-3))
+    @test all(isapprox.(confint(tta; tail=:right), (-13.0, Inf); atol=1e-3))
+
+    # and the 9 v 9 tied sample: R "less" -> (-Inf, 1.010023), "greater" -> (-0.098019, Inf)
+    @test all(isapprox.(confint(ta; tail=:left), (-Inf, 1.01); atol=1e-3))
+    @test all(isapprox.(confint(ta; tail=:right), (-0.098, Inf); atol=1e-3))
 
     # a narrower interval for a lower confidence level
     lo95, hi95 = confint(ExactMannWhitneyUTest(x, y); level=0.95)

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -23,7 +23,7 @@ end
     Exact Mann-Whitney U test
     -------------------------
     Population details:
-        parameter of interest:   Location parameter (pseudomedian)
+        parameter of interest:   Location shift
         value under h_0:         0
         point estimate:          -5.6
         95% confidence interval: (-11.1, -0.1)
@@ -103,7 +103,7 @@ end
     Exact Mann-Whitney U test
     -------------------------
     Population details:
-        parameter of interest:   Location parameter (pseudomedian)
+        parameter of interest:   Location shift
         value under h_0:         0
         point estimate:          -7.5
         95% confidence interval: (-14.0, -1.0)
@@ -122,7 +122,7 @@ end
     Exact Mann-Whitney U test
     -------------------------
     Population details:
-        parameter of interest:   Location parameter (pseudomedian)
+        parameter of interest:   Location shift
         value under h_0:         0
         point estimate:          7.5
         95% confidence interval: (1.0, 14.0)

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -391,6 +391,7 @@ end
     @test occursin("number of observations in each group", out)
     @test !occursin("confidence interval", out)
     @test !occursin("point estimate", out)
+    @test occursin("not computed (over MAX_PAIRWISE_ESTIMATES)", out)
 
     # and where it can afford one it still prints it
     @test occursin("95% confidence interval",

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -399,11 +399,20 @@ end
 end
 
 @testset "The exact interval is bounded in time" begin
-    # `exact_ci_index` runs a lattice recursion per candidate endpoint, which `:auto` never
-    # reached, since it leaves the exact route at nx + ny > 50. `method = :exact` does reach
-    # it at any size, so the interval is bounded rather than left to run.
-    x = collect(1.0:200); y = collect(1.5:1:200.5)
-    @test 200 * 200 > HypothesisTests.MAX_EXACT_CI_ESTIMATES
+    # `exact_ci_index` runs a `wilcoxcdf` lattice recursion per bisection step, which
+    # `:auto` never reaches, since it leaves the exact route at nx + ny > 50.
+    # `method = :exact` does reach it at any size, so the interval is bounded rather
+    # than left to run: about 11 s at the bound, a 300-against-300 design, and 35 s at
+    # 400 against 400. This is the only route the bound reaches, the signed rank
+    # bisection being cheap enough to run to its memory bound (see test/wilcoxon.jl).
+    @test HypothesisTests.MAX_EXACT_CI_ESTIMATES == 90_000
+    @test HypothesisTests.MAX_EXACT_CI_ESTIMATES < HypothesisTests.MAX_PAIRWISE_ESTIMATES
+    @test HypothesisTests.check_exact_ci_cost(90_000, "") === nothing
+    @test_throws HypothesisTests.ComputationTooLarge HypothesisTests.check_exact_ci_cost(90_001, "")
+
+    x = collect(1.0:400); y = collect(1.5:1:400.5)
+    @test 400 * 400 > HypothesisTests.MAX_EXACT_CI_ESTIMATES
+    # refused before the differences are formed, so the refusal is immediate
     @test_throws HypothesisTests.ComputationTooLarge confint(MannWhitneyUTest(x, y; method=:exact))
     # the approximate interval inverts a closed form, so it is unaffected
     @test confint(MannWhitneyUTest(x, y; method=:approximate)) isa Tuple

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -230,12 +230,9 @@ end
     @test all(isapprox.(confint(ta), (-0.37, 1.183); atol = 1e-4))
     @test hodgeslehmann(ta) ≈ 0.56
 
-    # PENDING #363: the reported estimate is still the difference of sample medians,
-    # not the Hodges-Lehmann estimate the "pseudomedian" label names and the interval
-    # above is built around. R reports 0.56005616 for this sample.
-    @test population_param_of_interest(ta)[3] ≈ 0.62
-    @test population_param_of_interest(ta)[3] == median(a) - median(b)
-    @test population_param_of_interest(ta)[3] != hodgeslehmann(ta)
+    # the estimate that is reported is the one the interval is built around
+    @test population_param_of_interest(ta)[3] == hodgeslehmann(ta)
+    @test population_param_of_interest(ta)[3] != median(a) - median(b)
 
     # one-sided bounds
     @test confint(ExactMannWhitneyUTest(x, y); tail=:left)[2] == Inf

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -445,4 +445,61 @@ end
         end
     end
 end
+
+@testset "The approximate interval rule is its own rule" begin
+    # on 3 v 6 the exact and the normal index rules pick different order statistics,
+    # so these two pins hold the routes apart. R: wilcox.test(x3, y6, conf.int = TRUE)
+    # -> (-8.0, 4.9); exact = FALSE -> (-9.09992, 6.09992), whose order statistics
+    # are (-9.1, 6.1).
+    x3 = [1.1, 4.7, 8.3]
+    y6 = [2.2, 3.4, 5.6, 6.8, 9.1, 10.2]
+    @test all(isapprox.(confint(ExactMannWhitneyUTest(x3, y6)), (-8.0, 4.9); atol = 1e-8))
+    @test all(isapprox.(confint(ApproximateMannWhitneyUTest(x3, y6)), (-9.1, 6.1); atol = 1e-8))
+end
+
+@testset "Approximate one-sided p-values against R" begin
+    # R: wilcox.test(1:10, seq(2.1, 21, 2), exact = FALSE, correct = TRUE,
+    #    alternative = "less") -> 0.0128740404106, "greater" -> 0.989433035935
+    am = ApproximateMannWhitneyUTest([1:10;], [2.1:2:21;])
+    @test isapprox(@inferred(pvalue(am; tail = :left)), 0.0128740404106, atol = 1e-10)
+    @test isapprox(@inferred(pvalue(am; tail = :right)), 0.989433035935, atol = 1e-10)
+end
+
+@testset "Tied exact one-sided intervals" begin
+    # under ties this route inverts the untied lattice; base R falls back to the
+    # normal approximation and lands on the same order statistics:
+    # wilcox.test(1:10, seq(2, 24, 2), conf.int = TRUE, alternative = "less") ->
+    # (-Inf, -2.000005), "greater" -> (-13.0, Inf)
+    tt = ExactMannWhitneyUTest([1:10;], [2:2:24;])
+    @test confint(tt; tail = :left) == (-Inf, -2.0)
+    @test confint(tt; tail = :right) == (-13.0, Inf)
+end
+
+@testset "Untied with nx > ny" begin
+    # exercises the swap onto the smaller sample on the StatsFuns route.
+    # R: wilcox.test(1:12, seq(2.5, 16.5, 2), conf.int = TRUE): W = 30,
+    # p = 0.181344764626, "less" -> 0.0906723823132, "greater" -> 0.921568627451,
+    # interval (-7.5, 1.5)
+    t = ExactMannWhitneyUTest([1:12;], [2.5:2:16.5;])
+    @test t.U == 30.0
+    @test isapprox(pvalue(t), 0.181344764626, atol = 1e-10)
+    @test isapprox(pvalue(t; tail = :left), 0.0906723823132, atol = 1e-10)
+    @test isapprox(pvalue(t; tail = :right), 0.921568627451, atol = 1e-10)
+    @test confint(t) == (-7.5, 1.5)
+end
+
+@testset "Tied auto boundary at N = 10 and 11" begin
+    xa = [1.0, 2.0, 2.0, 3.0, 7.0]
+    ya = [2.0, 4.0, 5.0, 6.0, 8.0]                   # N = 10, tied: still exact
+    @test MannWhitneyUTest(xa, ya) isa ExactMannWhitneyUTest
+    @test MannWhitneyUTest(xa, [ya; 9.0]) isa ApproximateMannWhitneyUTest
+end
+
+@testset "All-equal samples" begin
+    # R: exactRankTests::wilcox.exact(rep(1, 4), rep(1, 5)) -> p = 1
+    @test pvalue(ExactMannWhitneyUTest(ones(4), ones(5))) == 1
+    # mu and sigma are both zero here, which is its own branch of the normal route
+    @test pvalue(ApproximateMannWhitneyUTest(ones(4), ones(5))) == 1
+    @test pvalue(ApproximateMannWhitneyUTest(ones(4), ones(5)); tail = :left) == 1
+end
 end

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -159,6 +159,48 @@ end
     l = confint(SignedRankTest(x); tail=:right)[1]
     @test pvalue(SignedRankTest(x .- (l + 0.02)); tail=:right) > 0.05
     @test pvalue(SignedRankTest(x .- (l - 0.02)); tail=:right) < 0.05
+
+    # one-sided p-values on the same sample, against R:
+    # wilcox.test(x, alternative = "less")    -> 0.9986877441
+    # wilcox.test(x, alternative = "greater") -> 0.001678466797
+    @test isapprox(pvalue(ExactSignedRankTest(x); tail=:left), 0.9986877441, atol=1e-9)
+    @test isapprox(pvalue(ExactSignedRankTest(x); tail=:right), 0.001678466797, atol=1e-9)
+    # and the approximate route, R with exact = FALSE, correct = TRUE:
+    # "less" -> 0.9975337639, "greater" -> 0.002938062707
+    @test isapprox(pvalue(ApproximateSignedRankTest(x); tail=:left), 0.9975337639, atol=1e-9)
+    @test isapprox(pvalue(ApproximateSignedRankTest(x); tail=:right), 0.002938062707, atol=1e-9)
+    # approximate one-sided intervals: R solves numerically for (-Inf, 14.45001612) and
+    # (4.450022698, Inf); these are the order statistics it lands beside
+    @test confint(ApproximateSignedRankTest(x); tail=:left)[1] == -Inf
+    @test isapprox(confint(ApproximateSignedRankTest(x); tail=:left)[2], 14.45, atol=1e-4)
+    @test isapprox(confint(ApproximateSignedRankTest(x); tail=:right)[1], 4.45, atol=1e-4)
+    @test confint(ApproximateSignedRankTest(x); tail=:right)[2] == Inf
+
+    # the sample from #368, all three tails against R:
+    # wilcox.test(z, conf.int = TRUE, alternative = "less")    -> (-Inf, 0.95)
+    # wilcox.test(z, conf.int = TRUE, alternative = "greater") -> (-0.45, Inf)
+    # wilcox.test(z, conf.int = TRUE)                          -> (-0.7, 1.1)
+    z = [1.2, 2.3, 3.1, 4.4, 2.8, 3.9, 5.1, 2.2, 3.3, 4.0] .- 3
+    @test all(isapprox.(confint(ExactSignedRankTest(z); tail=:left), (-Inf, 0.95); atol=1e-9))
+    @test all(isapprox.(confint(ExactSignedRankTest(z); tail=:right), (-0.45, Inf); atol=1e-9))
+    @test all(isapprox.(confint(ExactSignedRankTest(z)), (-0.7, 1.1); atol=1e-9))
+end
+
+@testset "Tied one-sided p-values against exactRankTests" begin
+    # R's exactRankTests::wilcox.exact computes the same conditional distribution as the
+    # tied enumeration here. Its one-sided p-values are convention-free and pin ours
+    # exactly; its two-sided can differ from doubling only where the conditional
+    # distribution is asymmetric, which the sign-flip symmetry rules out one-sample.
+    h = [1, 2, 3, 4, 5, 6, 7, 10, 10, 10, 10, 10, 13, 14, 15] .- 10.1
+    # wilcox.exact(h): 0.04052734375; "less": 0.02026367188; "greater": 0.9828491211
+    @test pvalue(ExactSignedRankTest(h)) == 0.04052734375
+    @test isapprox(pvalue(ExactSignedRankTest(h); tail=:left), 0.02026367188, atol=1e-9)
+    @test isapprox(pvalue(ExactSignedRankTest(h); tail=:right), 0.9828491211, atol=1e-9)
+    # with zeros as well as ties; wilcox.exact drops the zeros likewise
+    # wilcox.exact(d): 0.3071899414; "less": 0.8592834473; "greater": 0.1535949707
+    d = [0, 0, 0, 0.5, 0.5, 1, -0.5, -1, 1.5, -1.5, 0.5, 0, 1, -0.5, 2, 0, 0.5, -1, 1, 0.5]
+    @test isapprox(pvalue(SignedRankTest(d); tail=:left), 0.8592834473, atol=1e-9)
+    @test isapprox(pvalue(SignedRankTest(d); tail=:right), 0.1535949707, atol=1e-9)
 end
 
 @testset "Hodges-Lehmann estimate" begin
@@ -223,8 +265,13 @@ end
     ci = @test_logs (:warn, r"not attainable") confint(ExactSignedRankTest(small))
     walsh = sort([(small[i] + small[j]) / 2 for i in eachindex(small) for j in i:length(small)])
     @test ci == (first(walsh), last(walsh))                   # the widest available
+    # R warns here too and returns the same interval: (-1.9, 2.3)
+    @test ci == (-1.9, 2.3)
     @test_logs (:warn, r"not attainable") confint(ExactSignedRankTest(small); level=0.99)
-    @test_logs (:warn, r"not attainable") confint(ExactMannWhitneyUTest([1.0, 2.0], [3.0, 4.0]))
+    # R returns (-3, -1) with an achieved conf.level attribute of 2/3, which is the
+    # attainable coverage the warning here names: 1 - 2 P(U <= 0) = 1 - 2/6
+    ci22 = @test_logs (:warn, r"not attainable") confint(ExactMannWhitneyUTest([1.0, 2.0], [3.0, 4.0]))
+    @test ci22 == (-3.0, -1.0)
     # the approximate route warns for its own reason, and does not claim unattainability:
     # at n = 8, level = 0.99 it asks for k = -1 while the exact route reaches 0.9922
     @test_logs (:warn, r"outside the set of pairwise estimates") confint(ApproximateSignedRankTest(small))

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -269,7 +269,9 @@ end
     ci = @test_logs (:warn, r"not attainable") confint(ExactSignedRankTest(small))
     walsh = sort([(small[i] + small[j]) / 2 for i in eachindex(small) for j in i:length(small)])
     @test ci == (first(walsh), last(walsh))                   # the widest available
-    # R warns here too and returns the same interval: (-1.9, 2.3)
+    # R returns the same interval, (-1.9, 2.3), but silently: its conf.level attribute
+    # still claims 0.95, and it warns only once the shortfall exceeds alpha/2, as at
+    # the 2 v 2 case below
     @test ci == (-1.9, 2.3)
     @test_logs (:warn, r"not attainable") confint(ExactSignedRankTest(small); level=0.99)
     # R returns (-3, -1) with an achieved conf.level attribute of 2/3, which is the

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -1,6 +1,7 @@
 using HypothesisTests, Test
 using HypothesisTests: default_tail, population_param_of_interest
-using Statistics: median
+using Statistics: median, quantile
+using Distributions: Normal
 
 # A parameterised route rule written the natural way, as a struct you can store, reuse
 # and print. It is callable, and it is not a subtype of `Function`: defining a call
@@ -110,7 +111,9 @@ end
 
 @testset "Tests for automatic selection" begin
     @test abs(@inferred(pvalue(SignedRankTest([1:10;], [2:2:20;]))) - 0.0020) <= 1e-4
-    @test abs(@inferred(pvalue(SignedRankTest([1:10;], [2:11;]))) - 0.0020) <= 1e-4
+    # 2/2^10 exactly, from the tied enumeration; the approximate route gives
+    # 0.0019042, which an atol of 1e-4 against 0.0020 would also have accepted
+    @test @inferred(pvalue(SignedRankTest([1:10;], [2:11;]))) == 0.001953125
 	@test default_tail(SignedRankTest([1:10;], [2:2:20;])) == :both
 	show(IOBuffer(), SignedRankTest([1:10;], [2:2:20;]))
 end
@@ -215,7 +218,8 @@ end
     @test population_param_of_interest(ExactSignedRankTest(x))[3] == hodgeslehmann(ExactSignedRankTest(x))
     @test population_param_of_interest(ExactSignedRankTest(x))[3] != median(x)
 
-    # ties: R reports -2.1
+    # ties: R's wilcox.test reports -2.1; exactRankTests::wilcox.exact reports -2.35,
+    # which is its conditional estimator, not this one
     h = [1, 2, 3, 4, 5, 6, 7, 10, 10, 10, 10, 10, 13, 14, 15] .- 10.1
     @test hodgeslehmann(SignedRankTest(h)) ≈ -2.1
 end
@@ -523,5 +527,54 @@ end
     # misses by its one overshooting tail only: 1 - 1/32, not 1 - 2/32
     @test logs[1].kwargs[:requested] == 0.99
     @test logs[1].kwargs[:attainable] == 1 - 1/32
+end
+
+@testset "One-sided intervals on the tied routes against R" begin
+    h = [1, 2, 3, 4, 5, 6, 7, 10, 10, 10, 10, 10, 13, 14, 15] .- 10.1
+    # base R falls back to the normal approximation under ties and lands on the same
+    # order statistics as this route, which inverts the untied lattice:
+    # wilcox.test(h, conf.int = TRUE, alternative = "less") -> (-Inf, -0.09997),
+    # "greater" -> (-4.10001, Inf). exactRankTests::wilcox.exact, which inverts the
+    # tied conditional distribution instead, gives (-4.6, Inf) for "greater".
+    te = ExactSignedRankTest(h)
+    @test confint(te; tail = :left)[1] == -Inf
+    @test isapprox(confint(te; tail = :left)[2], -0.1, atol = 1e-9)
+    @test isapprox(confint(te; tail = :right)[1], -4.1, atol = 1e-9)
+    @test confint(te; tail = :right)[2] == Inf
+
+    # the approximate test's tie-corrected sigma reaches one order statistic further
+    # on the left: R gives (-4.60008, -0.09997) with exact = FALSE
+    ta = ApproximateSignedRankTest(h)
+    @test all(isapprox.(confint(ta), (-4.6, -0.1); atol = 1e-9))
+end
+
+@testset "Auto boundaries at n = 50 and 51, against R" begin
+    s50 = quantile.(Normal(), (1:50) ./ 51) .+ 0.3
+    s51 = quantile.(Normal(), (1:51) ./ 52) .+ 0.3
+    @test SignedRankTest(s50) isa ExactSignedRankTest
+    @test SignedRankTest(s51) isa ApproximateSignedRankTest
+    # R switches at n < 50, so its exact side must be forced to compare:
+    # wilcox.test(qnorm((1:50)/51) + 0.3, exact = TRUE)  -> 0.0371666050798
+    # wilcox.test(qnorm((1:51)/52) + 0.3, exact = FALSE) -> 0.0345394645593
+    @test isapprox(pvalue(SignedRankTest(s50)), 0.0371666050798, atol = 1e-10)
+    @test isapprox(pvalue(SignedRankTest(s51)), 0.0345394645593, atol = 1e-10)
+end
+
+@testset "Tied auto boundary counts non-zero observations" begin
+    tied16 = repeat([1.0, -1.0, 2.5, 3.5], 4)        # 16 non-zero, tied
+    @test SignedRankTest(tied16) isa ApproximateSignedRankTest
+    @test SignedRankTest(tied16[1:15]) isa ExactSignedRankTest
+end
+
+@testset "Levels at the edges of (0.5, 1)" begin
+    x = [-7.8, -6.9, -4.7, 3.7, 6.5, 8.7, 9.1, 10.1, 10.8, 13.6, 14.4, 16.6, 20.2, 22.4, 23.5]
+    t = ExactSignedRankTest(x)
+    @test_throws ArgumentError confint(t; level = 0.5)
+    @test_throws ArgumentError confint(t; level = 1.0)
+    # R: wilcox.test(x, conf.int = TRUE, conf.level = 0.51) -> (7.85, 11.75)
+    @test all(isapprox.(confint(t; level = 0.51), (7.85, 11.75); atol = 1e-9))
+    # R: alternative = "less", conf.level = 0.99 -> (-Inf, 16.3)
+    @test confint(t; level = 0.99, tail = :left)[1] == -Inf
+    @test isapprox(confint(t; level = 0.99, tail = :left)[2], 16.3, atol = 1e-9)
 end
 end

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -483,4 +483,45 @@ end
         end
     end
 end
+
+@testset "AbstractVector inputs" begin
+    # ranges and views used to fail with a MethodError: the structs store Vector,
+    # and nothing converted on the way in
+    @test pvalue(SignedRankTest(-2:7)) == pvalue(SignedRankTest([-2:7;]))
+    @test pvalue(ExactSignedRankTest(-2:7)) == pvalue(ExactSignedRankTest([-2:7;]))
+    @test pvalue(ApproximateSignedRankTest(1.0:20.0)) ==
+          pvalue(ApproximateSignedRankTest([1.0:20.0;]))
+    v = [1.0, -2.0, 3.0, -4.0, 5.0, 6.0]
+    @test pvalue(SignedRankTest(view(v, 2:5))) == pvalue(SignedRankTest(v[2:5]))
+end
+
+@testset "No Int64 overflow at two million observations" begin
+    # nz(nz+1)(2nz+1) wrapped in Int64 from nz = 2^21, making sigma three orders of
+    # magnitude too small with no error raised; t^3 in the tie adjustment wrapped the
+    # same way for a single group of 2^21 equal values
+    nz = 2^21
+    t = ApproximateSignedRankTest(collect(1.0:nz))
+    @test t.sigma ≈ Float64(sqrt(big(nz) * (nz + 1) * (2 * nz + 1) // 24)) rtol = 1e-12
+    @test HypothesisTests.tiedrank_adj(fill(1.0, nz))[2] ≈ Float64(big(nz)^3 - nz) rtol = 1e-12
+end
+
+@testset "Attainable levels do not warn" begin
+    small = [1.4, -0.6, 2.3, 0.8, -1.9]              # n = 5: P(W <= 0) = 1/32
+    # alpha/2 = 1/32 exactly: k = 0 attains the request, so there is nothing to warn
+    # about. R returns the same (-1.9, 2.3) at conf.level = 0.9375, silently.
+    @test (@test_logs confint(ExactSignedRankTest(small); level = 1 - 2/32)) == (-1.9, 2.3)
+end
+
+@testset "One-sided warnings name the one-sided request" begin
+    small = [1.4, -0.6, 2.3, 0.8, -1.9]
+    logs, ci = Test.collect_test_logs() do
+        confint(ExactSignedRankTest(small); level = 0.99, tail = :left)
+    end
+    @test ci == (-Inf, 2.3)
+    @test length(logs) == 1
+    # the request was 0.99, not the two-sided 0.98 this used to report, and the bound
+    # misses by its one overshooting tail only: 1 - 1/32, not 1 - 2/32
+    @test logs[1].kwargs[:requested] == 0.99
+    @test logs[1].kwargs[:attainable] == 1 - 1/32
+end
 end

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -46,6 +46,21 @@ Base.getindex(v::ZeroBasedVector, i::Int) = v.data[i + 1]
     @test abs(@inferred(pvalue(ExactSignedRankTest([2:2:16; -1; 1], [1:10;]); tail = :right)) - 0.2158) <= 1e-4
 end
 
+@testset "Two-sided p-values are probabilities" begin
+    # Doubling a discrete tail overshoots at `W == n(n+1)/4`, which is attainable
+    # whenever `n(n+1)/2` is even. Sweep every sign pattern of every untied sample
+    # up to n = 12; 220 of the 8190 used to come back above 1.
+    signed_ranks(n, bits) =
+        [(bits >> (i - 1)) & 1 == 1 ? float(i) : -float(i) for i in 1:n]
+    overshoots = [(n, bits) for n in 1:12 for bits in 0:(2^n - 1)
+                  if pvalue(ExactSignedRankTest(signed_ranks(n, bits))) > 1]
+    @test isempty(overshoots)
+    # the worst of them: W = 3 = 3*4/4, both tails 0.625
+    @test pvalue(ExactSignedRankTest([1.0, 2.0, -3.0])) == 1
+    # and unchanged away from the null mean
+    @test pvalue(ExactSignedRankTest([1.0, 2.0, 3.0])) ≈ 0.25
+end
+
 @testset "Exact with ties" begin
     show(IOBuffer(), ExactSignedRankTest([1:10;], [1:10;]))
 

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -122,10 +122,9 @@ end
     # R: wilcox.test(x, conf.int = TRUE, exact = TRUE)  ->  (3.3, 15.5)
     @test isapprox(@inferred(confint(ExactSignedRankTest(x)))[1], 3.3, atol=1e-4)
     @test isapprox(@inferred(confint(ExactSignedRankTest(x)))[2], 15.5, atol=1e-4)
-    # PENDING #361: the approximate test still reports the exact interval, because
-    # `calculate_ci` inverts the exact null distribution whichever test it is called on.
-    # R with exact = FALSE gives (3.05004, 15.50001).
-    @test isapprox(@inferred(confint(ApproximateSignedRankTest(x)))[1], 3.3, atol=1e-4)
+    # R: wilcox.test(x, conf.int = TRUE, exact = FALSE)  ->  (3.05004, 15.50001).
+    # The approximate test now gets the approximate interval; it used to report the exact one.
+    @test isapprox(@inferred(confint(ApproximateSignedRankTest(x)))[1], 3.05, atol=1e-4)
     @test isapprox(@inferred(confint(ApproximateSignedRankTest(x)))[2], 15.5, atol=1e-4)
     @test isapprox(@inferred(confint(SignedRankTest(x); tail=:left))[1], 4.45, atol=1e-4)
     @test isapprox(@inferred(confint(SignedRankTest(x); tail=:right))[2], 14.45, atol=1e-4)
@@ -139,10 +138,9 @@ end
     @test hodgeslehmann(ExactSignedRankTest(x)) == hodgeslehmann(ApproximateSignedRankTest(x))
     lo, hi = confint(ExactSignedRankTest(x))
     @test lo <= hodgeslehmann(ExactSignedRankTest(x)) <= hi
-    # PENDING #363: the reported estimate is still the sample median, not the
-    # Hodges-Lehmann estimate the "pseudomedian" label names.
-    @test population_param_of_interest(ExactSignedRankTest(x))[3] == median(x) == 10.1
-    @test population_param_of_interest(ExactSignedRankTest(x))[3] != hodgeslehmann(ExactSignedRankTest(x))
+    # the estimate that is reported is the one the interval is built around
+    @test population_param_of_interest(ExactSignedRankTest(x))[3] == hodgeslehmann(ExactSignedRankTest(x))
+    @test population_param_of_interest(ExactSignedRankTest(x))[3] != median(x)
 
     # ties: R reports -2.1
     h = [1, 2, 3, 4, 5, 6, 7, 10, 10, 10, 10, 10, 13, 14, 15] .- 10.1
@@ -167,36 +165,23 @@ end
     @test confint(MannWhitneyUTest([4.0], [2.5])) == (1.5, 1.5)
 end
 
-@testset "Zero differences" begin
+@testset "Zero differences are dropped consistently" begin
+    # the statistic already ignores zeros; the interval and the estimate now do too
     d = [0.0, 0, 0, 0.5, 0.5, 1, -0.5, -1, 1.5, -1.5, 0.5, 0, 1, -0.5, 2, 0, 0.5, -1, 1, 0.5]
     nz = d[d .!= 0]
-    # the statistic and the p-value already ignore zeros
     @test SignedRankTest(d).W == SignedRankTest(nz).W
     @test pvalue(SignedRankTest(d)) == pvalue(SignedRankTest(nz))
-    # and so does the estimate, which is formed from the same pairwise estimates
-    @test hodgeslehmann(SignedRankTest(d)) == hodgeslehmann(SignedRankTest(nz)) == 0.5
-
-    # PENDING #362: the interval does not. It is built from the Walsh averages of all
-    # 20 differences rather than the 15 non-zero ones, so it describes a different
-    # sample from the p-value beside it. R gives (-0.24999, 0.75005) at this level.
-    @test confint(SignedRankTest(d); level=0.9) != confint(SignedRankTest(nz); level=0.9)
-    @test confint(SignedRankTest(d); level=0.9) == (0.0, 0.5)
+    @test confint(SignedRankTest(d); level=0.9) == confint(SignedRankTest(nz); level=0.9)
+    @test hodgeslehmann(SignedRankTest(d)) == hodgeslehmann(SignedRankTest(nz))
+    # R: wilcox.test(d, conf.int = TRUE, conf.level = 0.9) -> (-0.24999, 0.75005), est 0.5
+    @test confint(SignedRankTest(d); level=0.9) == (-0.25, 0.75)
+    @test hodgeslehmann(SignedRankTest(d)) == 0.5
+    # the interval is read off the 120 Walsh averages of the 15 non-zero differences,
+    # not the 210 of all 20
     @test length(HypothesisTests.walsh_averages(d)) == 210
     @test length(HypothesisTests.signedrank_pairwise_estimates(d)) == 120
-
-    # PENDING #362: and so the estimate can fall outside the interval printed beside it.
-    # Here the p-value and the estimate describe the seven non-zero differences while the
-    # interval is built from all fourteen, so it lands entirely below the estimate. The
-    # interval of the sample the estimate does describe contains it. This happens on
-    # roughly a tenth of samples that contain zeros, so it is worth a sample of its own.
-    e = [0.0, 3, 2, 0, 0, 3, 0, -1, 0, 0, 3, 0, 3, 3]
-    enz = e[e .!= 0]
-    @test pvalue(SignedRankTest(e)) == pvalue(SignedRankTest(enz))
-    @test hodgeslehmann(SignedRankTest(e)) == hodgeslehmann(SignedRankTest(enz)) == 3.0
-    lo, hi = confint(SignedRankTest(e))
-    @test (lo, hi) == (0.0, 1.5)
-    @test !(lo <= hodgeslehmann(SignedRankTest(e)) <= hi)
-    @test confint(SignedRankTest(enz)) == (1.0, 3.0)
+    # all-zero input still yields the degenerate interval rather than an error
+    @test confint(SignedRankTest(zeros(6))) == (0.0, 0.0)
 end
 
 @testset "method keyword" begin
@@ -229,8 +214,8 @@ end
     # than raising a MethodError from inside the constructor
     @test_throws ArgumentError SignedRankTest(x; method = (a, b) -> :exact)
 
-    # PENDING #361: the choice reaches the type but not yet the interval
-    @test confint(SignedRankTest(x; method=:exact)) ==
+    # the choice reaches the interval, not just the type
+    @test confint(SignedRankTest(x; method=:exact)) !=
           confint(SignedRankTest(x; method=:approximate))
 
     # the callable is handed the documented fields
@@ -244,6 +229,25 @@ end
     # and zeros are excluded from n_nonzero but not from n
     SignedRankTest([0.0, 1, 2, 3]; method = s -> (seen[] = s; :exact))
     @test (seen[].n, seen[].n_nonzero, seen[].ties) == (4, 3, false)
+end
+
+@testset "Interval invariants" begin
+    for n in (8, 13, 21, 34), seed in (1, 2)
+        v = [sin(seed * 1.7 + i * 0.9) * 3 + cos(i * 0.31) for i in 1:n]
+        for t in (SignedRankTest(v; method=:exact), SignedRankTest(v; method=:approximate))
+            # the estimate the interval is built around lies inside it
+            lo, hi = confint(t)
+            @test lo <= hodgeslehmann(t) <= hi
+            # raising the level cannot narrow the interval
+            wide = confint(t; level=0.99)
+            @test wide[1] <= lo && wide[2] >= hi
+            # one-sided bounds are the corresponding two-sided endpoints, and open
+            @test confint(t; tail=:left)[2] == Inf
+            @test confint(t; tail=:right)[1] == -Inf
+            @test confint(t; tail=:left)[1] >= lo
+            @test confint(t; tail=:right)[2] <= hi
+        end
+    end
 end
 
 @testset "Element types other than Float64" begin

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -143,8 +143,22 @@ end
     # The approximate test now gets the approximate interval; it used to report the exact one.
     @test isapprox(@inferred(confint(ApproximateSignedRankTest(x)))[1], 3.05, atol=1e-4)
     @test isapprox(@inferred(confint(ApproximateSignedRankTest(x)))[2], 15.5, atol=1e-4)
-    @test isapprox(@inferred(confint(SignedRankTest(x); tail=:left))[1], 4.45, atol=1e-4)
-    @test isapprox(@inferred(confint(SignedRankTest(x); tail=:right))[2], 14.45, atol=1e-4)
+    # one-sided, at level 0.95, is the corresponding endpoint of the two-sided 0.90
+    # interval, and the tail names the alternative: :left is location below the null, so it
+    # keeps the upper bound. R: wilcox.test(x, alternative = "less", conf.int = TRUE) ->
+    # (-Inf, 14.45), and "greater" -> (4.45, Inf). See #368.
+    @test @inferred(confint(SignedRankTest(x); tail=:left))[1] == -Inf
+    @test isapprox(@inferred(confint(SignedRankTest(x); tail=:left))[2], 14.45, atol=1e-4)
+    @test isapprox(@inferred(confint(SignedRankTest(x); tail=:right))[1], 4.45, atol=1e-4)
+    @test @inferred(confint(SignedRankTest(x); tail=:right))[2] == Inf
+    # and the pair matches what pvalue means by the same tail: the :left bound is the
+    # acceptance limit of the left-tailed test
+    u = confint(SignedRankTest(x); tail=:left)[2]
+    @test pvalue(SignedRankTest(x .- (u - 0.02)); tail=:left) > 0.05
+    @test pvalue(SignedRankTest(x .- (u + 0.02)); tail=:left) < 0.05
+    l = confint(SignedRankTest(x); tail=:right)[1]
+    @test pvalue(SignedRankTest(x .- (l + 0.02)); tail=:right) > 0.05
+    @test pvalue(SignedRankTest(x .- (l - 0.02)); tail=:right) < 0.05
 end
 
 @testset "Hodges-Lehmann estimate" begin
@@ -281,11 +295,12 @@ end
                 (@test_logs (:warn, r"outside the set of pairwise estimates") confint(t; level=0.99)) :
                 confint(t; level=0.99)
             @test wide[1] <= lo && wide[2] >= hi
-            # one-sided bounds are the corresponding two-sided endpoints, and open
-            @test confint(t; tail=:left)[2] == Inf
-            @test confint(t; tail=:right)[1] == -Inf
-            @test confint(t; tail=:left)[1] >= lo
-            @test confint(t; tail=:right)[2] <= hi
+            # one-sided bounds are the corresponding two-sided endpoints, and open on the
+            # side the tail's alternative allows (#368)
+            @test confint(t; tail=:left)[1] == -Inf
+            @test confint(t; tail=:right)[2] == Inf
+            @test confint(t; tail=:left)[2] <= hi
+            @test confint(t; tail=:right)[1] >= lo
         end
     end
 end

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -62,7 +62,9 @@ end
 end
 
 @testset "Exact with ties" begin
-    show(IOBuffer(), ExactSignedRankTest([1:10;], [1:10;]))
+    # every difference is zero here, so the interval shown cannot have 95% coverage and
+    # `show` says so
+    @test_logs (:warn, r"not attainable") show(IOBuffer(), ExactSignedRankTest([1:10;], [1:10;]))
 
     # Two-sided
     for kwargs in ((), (; tail = :both))
@@ -195,8 +197,28 @@ end
     # not the 210 of all 20
     @test length(HypothesisTests.walsh_averages(d)) == 210
     @test length(HypothesisTests.signedrank_pairwise_estimates(d)) == 120
-    # all-zero input still yields the degenerate interval rather than an error
-    @test confint(SignedRankTest(zeros(6))) == (0.0, 0.0)
+    # all-zero input still yields the degenerate interval rather than an error, and says
+    # that the level was not met
+    @test (@test_logs (:warn, r"not attainable") confint(SignedRankTest(zeros(6)))) == (0.0, 0.0)
+end
+
+@testset "Unattainable levels warn" begin
+    # the widest interval a sample of n has is (V_(1), V_(m)), covering 1 - 2^(1-n), so
+    # 0.95 is out of reach below n = 6 and 0.99 below n = 8
+    small = [1.4, -0.6, 2.3, 0.8, -1.9]                       # n = 5, widest is 0.9375
+    ci = @test_logs (:warn, r"not attainable") confint(ExactSignedRankTest(small))
+    walsh = sort([(small[i] + small[j]) / 2 for i in eachindex(small) for j in i:length(small)])
+    @test ci == (first(walsh), last(walsh))                   # the widest available
+    @test_logs (:warn, r"not attainable") confint(ExactSignedRankTest(small); level=0.99)
+    @test_logs (:warn, r"not attainable") confint(ExactMannWhitneyUTest([1.0, 2.0], [3.0, 4.0]))
+    # the approximate route warns for its own reason, and does not claim unattainability:
+    # at n = 8, level = 0.99 it asks for k = -1 while the exact route reaches 0.9922
+    @test_logs (:warn, r"outside the contrast set") confint(ApproximateSignedRankTest(small))
+    @test_logs (:warn, r"outside the contrast set") confint(
+        ApproximateSignedRankTest([1.4, -0.6, 2.3, 0.8, -1.9, 3.1, 2.7, -0.3]); level=0.99)
+    # and no warning once the level is attainable
+    @test_logs confint(ExactSignedRankTest([1.4, -0.6, 2.3, 0.8, -1.9, 3.1]))
+    @test_logs confint(ExactSignedRankTest(collect(1.0:15)); level=0.99)
 end
 
 @testset "method keyword" begin
@@ -253,8 +275,11 @@ end
             # the estimate the interval is built around lies inside it
             lo, hi = confint(t)
             @test lo <= hodgeslehmann(t) <= hi
-            # raising the level cannot narrow the interval
-            wide = confint(t; level=0.99)
+            # raising the level cannot narrow the interval (the approximate route warns at
+            # n = 8, where its rule wants an endpoint outside the contrast set)
+            wide = n == 8 && t isa ApproximateSignedRankTest ?
+                (@test_logs (:warn, r"outside the contrast set") confint(t; level=0.99)) :
+                confint(t; level=0.99)
             @test wide[1] <= lo && wide[2] >= hi
             # one-sided bounds are the corresponding two-sided endpoints, and open
             @test confint(t; tail=:left)[2] == Inf

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -226,21 +226,26 @@ end
 
 @testset "One observation" begin
     # One difference gives one Walsh average, so the only interval is that point, and
-    # the scan that picks an order statistic has nothing to pick between: it was handed
-    # the empty range 1:0 and `argmin` raised. R's `wilcox.test` returns (1.5, 1.5).
+    # the index rule has nothing to choose between: the scan this bisection replaced was
+    # handed the empty range 1:0 and `argmin` raised. R's `wilcox.test` returns (1.5, 1.5).
+    #
+    # Every interval here warns, and should: one observation cannot cover 95% by either
+    # route. The exact route names the coverage it does reach, 0 two-sided and 0.5
+    # one-sided; the approximate route reports its endpoint falling outside the set
+    # instead, since unattainability is not what its rule establishes.
     t = SignedRankTest([1.5])
-    @test confint(t) == (1.5, 1.5)
-    @test confint(t; level=0.99) == (1.5, 1.5)
+    @test (@test_logs (:warn, r"not attainable") confint(t)) == (1.5, 1.5)
+    @test (@test_logs (:warn, r"not attainable") confint(t; level=0.99)) == (1.5, 1.5)
     # `tail = :left` keeps the endpoint inverting the test of the same name (#368)
-    @test confint(t; tail=:left) == (-Inf, 1.5)
-    @test confint(t; tail=:right) == (1.5, Inf)
+    @test (@test_logs (:warn, r"not attainable") confint(t; tail=:left)) == (-Inf, 1.5)
+    @test (@test_logs (:warn, r"not attainable") confint(t; tail=:right)) == (1.5, Inf)
     @test hodgeslehmann(t) == 1.5
     @test pvalue(t) == 1.0
-    @test confint(ApproximateSignedRankTest([1.5])) == (1.5, 1.5)
+    @test (@test_logs (:warn, r"outside the set of pairwise estimates") confint(ApproximateSignedRankTest([1.5]))) == (1.5, 1.5)
     # and through the two-sample form
-    @test confint(SignedRankTest([4.0], [2.5])) == (1.5, 1.5)
+    @test (@test_logs (:warn, r"not attainable") confint(SignedRankTest([4.0], [2.5]))) == (1.5, 1.5)
     # the two-sample tests already agreed: one against one is the one difference
-    @test confint(MannWhitneyUTest([4.0], [2.5])) == (1.5, 1.5)
+    @test (@test_logs (:warn, r"not attainable") confint(MannWhitneyUTest([4.0], [2.5]))) == (1.5, 1.5)
 end
 
 @testset "Zero differences are dropped consistently" begin
@@ -476,8 +481,14 @@ end
             @test pvalue(a) == pvalue(b)
             @test pvalue(a; tail=:left) == pvalue(b; tail=:right)
             for level in (0.90, 0.95, 0.99)
-                lo_a, hi_a = confint(a; level=level)
-                lo_b, hi_b = confint(b; level=level)
+                # these samples are small enough that the higher levels are out of
+                # reach, so both routes warn here. That behaviour is pinned in
+                # "Unattainable levels warn"; in this testset it is noise, and the
+                # identity being checked is the reflection.
+                (lo_a, hi_a), (lo_b, hi_b) =
+                    Base.CoreLogging.with_logger(Base.CoreLogging.NullLogger()) do
+                        confint(a; level=level), confint(b; level=level)
+                    end
                 @test lo_a == -hi_b
                 @test hi_a == -lo_b
             end

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -213,8 +213,8 @@ end
     @test_logs (:warn, r"not attainable") confint(ExactMannWhitneyUTest([1.0, 2.0], [3.0, 4.0]))
     # the approximate route warns for its own reason, and does not claim unattainability:
     # at n = 8, level = 0.99 it asks for k = -1 while the exact route reaches 0.9922
-    @test_logs (:warn, r"outside the contrast set") confint(ApproximateSignedRankTest(small))
-    @test_logs (:warn, r"outside the contrast set") confint(
+    @test_logs (:warn, r"outside the set of pairwise estimates") confint(ApproximateSignedRankTest(small))
+    @test_logs (:warn, r"outside the set of pairwise estimates") confint(
         ApproximateSignedRankTest([1.4, -0.6, 2.3, 0.8, -1.9, 3.1, 2.7, -0.3]); level=0.99)
     # and no warning once the level is attainable
     @test_logs confint(ExactSignedRankTest([1.4, -0.6, 2.3, 0.8, -1.9, 3.1]))
@@ -276,9 +276,9 @@ end
             lo, hi = confint(t)
             @test lo <= hodgeslehmann(t) <= hi
             # raising the level cannot narrow the interval (the approximate route warns at
-            # n = 8, where its rule wants an endpoint outside the contrast set)
+            # n = 8, where its rule wants an endpoint outside the pairwise estimates)
             wide = n == 8 && t isa ApproximateSignedRankTest ?
-                (@test_logs (:warn, r"outside the contrast set") confint(t; level=0.99)) :
+                (@test_logs (:warn, r"outside the set of pairwise estimates") confint(t; level=0.99)) :
                 confint(t; level=0.99)
             @test wide[1] <= lo && wide[2] >= hi
             # one-sided bounds are the corresponding two-sided endpoints, and open

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -419,20 +419,15 @@ end
     @test HypothesisTests.rank_binomial(10^6, 10^6) === nothing
     @test_throws HypothesisTests.ComputationTooLarge HypothesisTests.check_exact_enumeration(10^6, 10^6)
 
-    # the exact interval is bounded separately and far lower, because choosing an endpoint
-    # costs a lattice recursion per candidate rather than a slot in an array
-    @test HypothesisTests.MAX_EXACT_CI_ESTIMATES == 25_000
-    @test HypothesisTests.MAX_EXACT_CI_ESTIMATES < HypothesisTests.MAX_PAIRWISE_ESTIMATES
-    @test HypothesisTests.check_exact_ci_cost(25_000, "") === nothing
-    @test_throws HypothesisTests.ComputationTooLarge HypothesisTests.check_exact_ci_cost(25_001, "")
-
-    # the scan is what #97 describes, and it is reached by both signed rank types, since
-    # neither has an approximate interval yet. n = 300 forms m = 45,150 Walsh averages,
-    # small enough to materialise, so this refusal is check_exact_ci_cost itself,
-    # reached through `confint`
-    @test_throws HypothesisTests.ComputationTooLarge confint(ExactSignedRankTest(collect(1.0:300)))
-    # while n = 2000, the size #97 reports hanging, is stopped a check earlier, by the
-    # memory bound on materialising the set at all
+    # the signed rank exact interval carries no time bound of its own: the bisection is
+    # cheap enough that the memory bound above is the one it meets. n = 300 forms
+    # m = 45,150 Walsh averages and inverts in under a tenth of a second, where the
+    # m/2-recursion scan this branch replaced took 39 s and the branch below refused
+    # past n = 223 (MAX_EXACT_CI_ESTIMATES bounds the two-sample route alone now; its
+    # boundary is asserted in test/mann_whitney.jl)
+    @test confint(ExactSignedRankTest(collect(1.0:300))) isa Tuple
+    # n = 2000, the size #97 reports hanging, is stopped by the memory bound on
+    # materialising the set at all
     big = SignedRankTest(collect(1.0:2000))
     @test_throws HypothesisTests.ComputationTooLarge confint(big)
     # the test is still printable, without its interval line

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -231,8 +231,9 @@ end
     t = SignedRankTest([1.5])
     @test confint(t) == (1.5, 1.5)
     @test confint(t; level=0.99) == (1.5, 1.5)
-    @test confint(t; tail=:left) == (1.5, Inf)
-    @test confint(t; tail=:right) == (-Inf, 1.5)
+    # `tail = :left` keeps the endpoint inverting the test of the same name (#368)
+    @test confint(t; tail=:left) == (-Inf, 1.5)
+    @test confint(t; tail=:right) == (1.5, Inf)
     @test hodgeslehmann(t) == 1.5
     @test pvalue(t) == 1.0
     @test confint(ApproximateSignedRankTest([1.5])) == (1.5, 1.5)
@@ -485,7 +486,9 @@ end
                 @test lo_a == -hi_b
                 @test hi_a == -lo_b
             end
-            @test confint(a; tail=:left)[1] == -confint(b; tail=:right)[2]
+            # compare the finite ends: under the #368 convention `:left` is an upper
+            # bound and `:right` a lower one, so `[1]` on both would be -Inf either way
+            @test confint(a; tail=:left)[2] == -confint(b; tail=:right)[1]
         end
     end
 end


### PR DESCRIPTION
**Breaking.** The second of the three replacing #366, on top of #367, which is merged. [The docs PR](https://github.com/yoninazarathy/HypothesisTests.jl/pull/3) is stacked on this one and is documentation only; it will be opened here once this lands.

Closes #361, #362, #363 and #368. Further defects found while writing the specification appendix, and in review passes against R and against the code, are fixed here too. Every change here alters numbers this package returns today, or what the documentation claims about them. The one exception is the commit at the tip, which sets `version = "0.12.0"`: the bump was deferred out of #367 in `fa7f790`, so that nothing between the two could be registered by accident, and this is where the break completes, so this is where it lands.

## The interval now depends on which test you selected (#361)

`StatsAPI.confint` was defined identically on both signed rank types and called `signrankcdf` either way, so selecting `ApproximateSignedRankTest` did not produce an approximate interval: the package had no normal-approximation signed rank interval at all, and the tie correction the approximate type carries in `sigma` never reached its interval.

`Exact*` now inverts the exact null distribution; `Approximate*` inverts the normal approximation, with a continuity correction and the tie-corrected variance.

## Level selection is conservative rather than nearest (#361)

`argmin(abs.(l .- c))` could settle on an attainable coverage *below* nominal. Taking instead the largest index that still attains the level reproduces R's `qsignrank` rule on all 67 sample sizes `n = 5:71`, at 0.80, 0.90, 0.95 and 0.99. The old rule agreed with R on 30, 35, 32 and 27 of those respectively.

It is also a binary search rather than a scan over every index, so it runs `O(log n)` lattice recursions where the old rule ran `O(n^2)`.

## Zero differences are dropped for the interval too (#362)

`signedrankstats` drops them before ranking, so the statistic and the p-value describe the non-zero differences, but the interval was built from the Walsh averages of *all* of them: 210 against 120, on a 20-point sample with five zeros. The p-value and the interval described different samples.

## The reported estimate is the Hodges-Lehmann estimate (#363)

On all four types. The label said "pseudomedian"; the value was `median(x)`, or `median(x) - median(y)`. The Hodges-Lehmann estimate, the median of the pairwise estimates the interval is read off, is a different quantity from either: `0.62` against `0.56` on the tied nine-against-nine Mann-Whitney sample, and `10.1` against `9.675` on the fifteen-point signed rank one.

The Mann-Whitney half is a separate commit here rather than travelling with the interval that made it visible, so that #367 could stay strictly non-breaking.

`calculate_ci` goes with them; every caller now routes through the shared index rules. Across the whole PR the source grows by 55 lines net, over 230 added and 175 removed, most of the addition being comments and docstrings.

## One-sided intervals used the opposite convention to the rest of the package (#368)

`confint(test; tail = :left)` returned a *lower* bound for all four rank tests, and an upper bound for eight of the nine other `confint` methods here that take a `tail`: the three t-tests, the three z-tests, `BinomialTest` and `FisherExactTest`. R returns an upper bound under `alternative = "less"`, so the rank tests disagreed with R as well.

`SignTest` is the ninth, and is wrong in two separate ways, both out of scope here. Its `tail = :left` returns a lower bound as these four did, which is this same defect and is filed as JuliaStats/HypothesisTests.jl#372. Independently of orientation, it bounds the other side by the hypothesised median rather than leaving it infinite, so the interval moves when the null moves and either endpoint can end up on the wrong side, which is JuliaStats/HypothesisTests.jl#369.

The naming is the smaller half of it. On the same object, `pvalue` and `confint` given the same `tail` described opposite alternatives: `pvalue(t; tail = :left)` tests location below the null, whose acceptance region is an upper bound, while `confint(t; tail = :left)` returned the acceptance region of the *right*-tailed test. A caller who picked a tail once and used it for both got a mismatched pair from the rank tests and a matched one from everything else.

Each tail now keeps the endpoint that inverts the test of the same name. The endpoints keep their values; only which one is returned changes. On the sample from the issue:

| | before | after | R |
|:---|:---|:---|:---|
| `tail = :left` | `(-0.45, Inf)` | `(-Inf, 0.95)` | `(-Inf, 0.95)` |
| `tail = :right` | `(-Inf, 0.95)` | `(-0.45, Inf)` | `(-0.45, Inf)` |

The tests now assert the pairing directly rather than the orientation alone, shifting the null across each endpoint and checking which one-sided p-value crosses 0.05 there.

## The exact two-sided p-value could exceed 1

`pvalue(ExactSignedRankTest([1.0, 2.0, -3.0]))` returned `1.25`.

The untied branch doubled the tail on whichever side of the null mean `W` fell, without clipping. Where `n(n+1)/2` is even the null mean `n(n+1)/4` is itself attainable, and a statistic sitting on it has both tails equal to `(1 + P(W == mean))/2`, so the doubled tail comes to `1 + P(W == mean)`.

Sweeping every sign pattern of every untied sample up to `n = 12`, 220 of 8190 returned a p-value above 1, the largest `1.25` at `n = 3`. The affected sizes are `n ≡ 0, 3 (mod 4)`.

The three neighbouring exact routes already clip: the tied branch immediately below does `min(1, 2 * minimum(...))`, and both branches of the exact Mann-Whitney p-value do `min(2 * p, 1.0)`. This brings the fourth into line. Nothing away from the null mean moves, and no existing test changed.

## The documented null was the wrong one

All three signed rank docstrings gave the null as "the distribution of `x` has zero median". The test does not control that null. Its exact null distribution comes from the signs being independent of the magnitudes and each ± with probability 1/2, which symmetry about zero gives and a zero median alone does not.

At a nominal 0.05, over 20000 samples of `n = 20` drawn from median-zero but asymmetric distributions, the two-sided test rejects at 0.101 for `Exponential(1) - ln 2` and 0.110 for `LogNormal(0,1) - 1`, against 0.0498 for a symmetric `Normal(0,1)`. The docstrings now say symmetry, and name the pseudomedian as the location estimated, which is what `hodgeslehmann` and `population_param_of_interest` already report. The alternative is stated as the negation of the null rather than as symmetry about some other location, which excluded the asymmetric alternatives the test also has power against, and the automatic selection rule is given as one threshold per tie pattern rather than as a single sentence carrying both.

## The Mann-Whitney null was stated as the wrong hypothesis

All three Mann-Whitney docstrings gave the null as `P(x > y) = P(y > x)`. The test does not control that hypothesis. Its exact null distribution comes from the pooled observations being exchangeable, which `F_x = F_y` gives and that weaker equality does not: it leaves the two distributions free to differ in spread.

Simulated at a nominal 0.05, `X ~ Normal(0, 1)` against `Y ~ Normal(0, 3)`, three times the spread, so that `P(X > Y) = 1/2` holds exactly by symmetry, 20000 replicates each:

| `(nx, ny)` | exact | approximate |
|---|---|---|
| `(30, 10)` | 0.1295 | 0.1236 |
| `(20, 20)` | 0.0706 | 0.0706 |
| `(10, 30)` | 0.0162 | 0.0144 |
| `(5, 45)` | 0.0013 | 0.0013 |

Against 0.0493 and 0.0466 for `(10, 30)` and `(5, 45)` when `F_x = F_y`. The error runs in both directions, set by which sample is larger, so it cannot be waved through as conservative.

Both `Approximate*` docstrings also labelled their **variance** as σ; both now say σ². And both presented μ = n(n+1)/4 (or n_x n_y/2) while `show` prints `normal approximation (μ, σ)` with the statistic *centred* at that mean, -37.5 where the docstring's μ would be 60 on the worked two-sample example; the docstrings now call the null mean μ₀ and say the reported pair is (W − μ₀, σ), which is also how the specification writes it.

## `show` reported a count nothing was computed from

For a 20-point sample with five zero differences it printed `number of observations: 20`, while the statistic, p-value, estimate and interval were all computed from the other 15. Both counts are now printed:

```
number of observations:         20
non-zero observations:          15
```

## An unattainable confidence level passed silently

The widest interval this construction admits is `(V_(1), V_(m))`, whose coverage is `1 - 2 P(W <= 0)`, or `1 - 2^(1-n)` for an untied signed rank sample: `0.75`, `0.875` and `0.9375` at `n = 3, 4, 5`. So `level = 0.95` is unattainable below `n = 6` and `level = 0.99` below `n = 8`, and `confint` returned the widest interval it had without saying it fell short. `show` printed a "95% confidence interval" that was not one.

Both routes still return that interval, since it is the best available, but now say so. The exact route names the coverage that is attainable. (R does not warn here: at `n = 5` and `level = 0.95` it returns the same interval silently, its `conf.level` attribute still claiming `0.95`; it renames the attribute and warns only once the shortfall exceeds `alpha/2`, as at 2 v 2, where the attribute becomes 2/3.) The approximate route cannot name a coverage: its rule asks for an order statistic outside the pairwise estimates on small samples, and that is not the same thing, since at `n = 8` and `level = 0.99` it wants `k = -1` while the exact route reaches `0.9922`. So it reports what happened and points at `method = :exact`.

Two refinements to the same warnings, from review. The warning no longer fires when `P(W <= 0)` equals `alpha/2` exactly, where the widest interval attains the request (at `n = 5` that is `level = 0.9375`, and R agrees with the returned interval there). And a one-sided call is warned about in its own terms, the level actually asked for and the one-sided attainable coverage `1 - P(W <= 0)`; it previously reported the two-sided `2*level - 1` as the request and a two-sided coverage as what was attainable.

## Two Int64 overflows, found in review

The approximate signed rank variance formed `nz * (nz + 1) * (2 * nz + 1)` in `Int64`, which wraps from `nz = 2^21`; at exactly `2^21` non-zero observations the product wraps to a *positive* wrong value, so `sigma` came out three orders of magnitude too small, over-rejecting massively with no error raised. `tiedrank_adj` had the same problem in `t^3 - t` for a single tie group of `2^21` or more equal values. Both products now form in `Int128`: below the old wrap point the results are bit-identical, and a test pins the `2^21` case against `BigInt` arithmetic. Both overflows predate this stack.

## The signed rank constructors rejected everything but `Vector`

They declared `AbstractVector` but passed the input straight to struct fields typed `Vector`, so `SignedRankTest(1:5)`, ranges, and views threw a `MethodError`. They convert on the way in now, as the Mann-Whitney constructors always have. Also pre-existing on `master`.

## Two `show` labels said the wrong thing

The signed rank tests labelled `W⁺` as `Wilcoxon rank-sum statistic`, which is the two-sample test's name; the line now reads `Wilcoxon signed rank statistic`. And the Mann-Whitney tests reported their parameter of interest as `Location parameter (pseudomedian)`, the one-sample estimand; under the shift model the two-sample parameter is the shift, estimated by the median of the cross-group differences, so they now report `Location shift`, as R's `wilcox.test` calls it. Printed output only, and both labels predate this stack.

---

## Migration

*Written to be pasted into the release notes of 0.12.0; there is no `CHANGELOG.md`.*

> Confidence intervals and point estimates from `SignedRankTest`, `ExactSignedRankTest` and `ApproximateSignedRankTest` change value, and one-sided intervals from all four rank tests change which endpoint they return.
>
> - The interval returned by `ApproximateSignedRankTest` is now the normal-approximation interval rather than the exact one. `method = :exact`, or `ExactSignedRankTest`, recovers the previous construction.
> - Intervals are now conservative: the attained coverage is the smallest available that is at or above the requested level, where previously it was the closest available, which could be below it. Intervals are therefore never narrower than before, and are wider on roughly half of sample sizes.
> - Samples containing zero differences now yield an interval and an estimate computed from the non-zero differences only, matching the p-value, which already ignored them.
> - The reported point estimate, for the Mann-Whitney tests as well as the signed rank ones, is the Hodges-Lehmann estimate, available directly as `hodgeslehmann`. It was the sample median, or the difference of sample medians. Exact symmetry makes the two agree, but they can also agree by coincidence, as on `[1, 3, 3, 8]`, where both are `3`.
> - `confint(test; tail = :left)` on any of the four rank tests now returns an upper bound, `(-Inf, hi)`, and `tail = :right` a lower bound, `(lo, Inf)`. They were the other way round. This matches the other eight tests in this package that accept a `tail`, and R's `alternative = "less"` and `"greater"`. Code that passed a tail to a rank `confint` and used the finite endpoint needs the other tail; code that read the endpoint positionally needs to swap indices.
>
> - Two-sided p-values from `ExactSignedRankTest` on untied samples are now capped at 1. They could previously exceed it, by up to 0.25, when the statistic landed exactly on its null mean.
>
> - The signed rank tests print an extra `non-zero observations` line, and the documented null hypotheses change wording without any change in what is computed.
>
> - `confint` on a sample too small for the requested level now warns, naming the attainable coverage. The widest-interval return there comes from the conservative-rule change above; the warning itself changes no value.
>
> - The signed rank `show` statistic line reads `Wilcoxon signed rank statistic`, and the Mann-Whitney parameter of interest reads `Location shift`. Printed output only.
>
> - `SignedRankTest` and both concrete signed rank constructors accept any `AbstractVector`, and the approximate signed rank `sigma` is correct past two million non-zero observations, where it silently wrapped `Int64` before.
>
> There is no opt-out for the corrections from the p-value cap down; they are corrections rather than choices.

## The interval bound, re-measured against the bisection

`MAX_EXACT_CI_ESTIMATES = 25_000` was sized in #367 against the `m/2`-recursion endpoint scan that #361 deletes here, about 9 s at the bound, a signed rank sample of 223. Re-measured against the bisection, the cost turns out to have moved routes: the expensive lattice recursion is now the two-sample `wilcoxcdf`, not the one-sample `signrankcdf`. So the recalibration splits by route rather than moving one number.

The **signed rank** exact interval sheds the time bound entirely: running to the memory bound, a sample of 1413, costs about 6 s in total, under the old ceiling, and `n = 300` answers in under a tenth of a second, where the scan this replaced took 39 s and `master` as it stands, since #367, refuses. The refusal band #367 documents, samples of 224 to 1413, closes here.

The **Mann-Whitney** exact interval keeps the bound at the same wall-clock ceiling re-measured: `90_000`, which admits a 300-against-300 design at about 11 s and refuses 400 against 400 before the differences are formed (35 s if allowed). `method = :approximate` stays the unbounded escape. The constant's docstring, the manual's bounds prose, the boundary assertions, and the routing tables in the docs PR move in step.

## What this deliberately leaves open

JuliaStats/HypothesisTests.jl#371. The estimate and the interval are read off a set of pairwise estimates, and that set is materialised in full to take three order statistics out of it. This branch does not change that, and in one respect makes it more visible: #363 makes the reported estimate the Hodges-Lehmann one, so `show` now builds the set twice, once for the estimate and once for the interval, where before it built it once.

The direction of travel is still strongly downwards. The scan #361 replaces dominated everything else: `confint(SignedRankTest(randn(400)))` took 164 s before this branch and takes 0.0012 s after it. What is left is memory rather than time, and it is bounded rather than unbounded: `MAX_PAIRWISE_ESTIMATES` refuses instead of thrashing, at `n = 1413`, where the set is about 8 MB and sorting it costs as much again. Selecting the three order statistics rather than sorting for them would need neither.

Selecting the three order statistics directly is exact and changes no returned value, so it is a self-contained follow-up rather than part of a breaking change, and it is worth more after this branch than before it: until #361 lands, the signed rank interval is dominated by that scan and not by the allocation. #371 carries the measurements and a checked proof of concept.

## Blast radius

Indicative only, since GitHub code search does not index everything and misses private code, but across the public corpus there are **no** hits for `confint` used with `SignedRankTest` or `MannWhitneyUTest`, against 12 and 9 repos referencing the `Exact*` and `Approximate*` types. Which is about what you would expect for a function that returned the exact interval regardless of which test you asked it for.

## Tests

Wilcoxon 412 (was 249 on `master` after #367, 62 before it); Mann-Whitney 308 (was 271 after #367, 77 before it).

The p-value sweep is one assertion over all 8190 sign patterns up to `n = 12`, reporting the offending `(n, bits)` pairs rather than a count of failures.

The six `PENDING` assertions #367 left behind become their fixed counterparts, which is the whole of the behaviour change as seen from the test suite: the approximate interval becomes `(3.05, 15.5)` against R's `(3.05004, 15.50001)`, the zeros sample `(-0.25, 0.75)` against R's `(-0.24999, 0.75005)`, the reported estimate becomes the Hodges-Lehmann one, and `method` reaches the interval rather than only the returned type.

New invariants across sizes and both routes: the estimate lies inside its own interval, the interval cannot narrow as the level rises, and each one-sided bound is the corresponding two-sided endpoint with the far side open and on the side its own tail's alternative allows.

A review pass added the pins the suite could not previously distinguish, each against R: a 3 v 6 sample on which the exact and approximate Mann-Whitney interval rules pick different order statistics, so a silent fallback from one rule to the other now fails; the continuity-corrected one-sided approximate Mann-Whitney p-values; the exact tied one-sided intervals of both tests and the tied approximate signed rank interval, the one place the tie-corrected `sigma` moves an endpoint; a 12 v 8 untied sample through the `nx > ny` swap on the StatsFuns route; the automatic rule's boundaries, `n = 50/51` pinned against R on both sides and the tied 15/16 and 10/11 asserted by type; levels at the edges, where 0.5 and 1.0 throw and 0.51 and a one-sided 0.99 match R; and all-equal samples returning `p = 1` on both routes.

Every route this PR touches is additionally pinned to a reference value rather than to a structural property alone: exact and approximate one-sided p-values and intervals against `wilcox.test` with `alternative` set, the tied one-sided p-values of both tests against `exactRankTests::wilcox.exact` to nine digits, and the degenerate small-sample intervals against what R returns there, `(-1.9, 2.3)` at `n = 5` and `(-3, -1)` for 2 v 2, where R's achieved `conf.level` attribute, 2/3, is the same attainable coverage the warning here names. One convention difference is recorded in a test comment rather than papered over: `wilcox.exact` sums the far tail for its two-sided value where this package doubles the smaller one, so the two-sided values agree one-sample, where the tied conditional distribution is symmetric, and differ two-sample, where it is not (`0.0120034764` against `0.0118890398` on the tied 10 v 12 sample); the one-sided values, which no convention touches, agree exactly.











