### PR TITLE
Clip the exact signed rank two-sided p-value at 1

### DIFF
--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -163,11 +163,13 @@ function StatsAPI.pvalue(x::ExactSignedRankTest; tail=:both)
     elseif x.tie_adjustment == 0
         # Compute exact p-value using method from StatsFuns, which is fast but cannot account for ties
         if tail == :both
-            if x.W <= n * (n + 1)/4
-                2 * signrankcdf(n, x.W)
-            else
-                2 * signrankccdf(n, x.W - 1)
-            end
+            # The smaller tail, doubled and clipped. Doubling a discrete tail can
+            # overshoot: where n(n+1)/2 is even the null mean is attainable, and at
+            # W == n(n+1)/4 each tail is (1 + P(W == mean))/2, so the doubling gives
+            # 1 + P(W == mean), which is 1.25 for n = 3 at W = 3. The tied branch below
+            # and both exact Mann-Whitney branches clip for the same reason.
+            p = x.W <= n * (n + 1)/4 ? signrankcdf(n, x.W) : signrankccdf(n, x.W - 1)
+            min(2 * p, 1.0)
         elseif tail == :left
             signrankcdf(n, x.W)
         else

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -46,6 +46,21 @@ Base.getindex(v::ZeroBasedVector, i::Int) = v.data[i + 1]
     @test abs(@inferred(pvalue(ExactSignedRankTest([2:2:16; -1; 1], [1:10;]); tail = :right)) - 0.2158) <= 1e-4
 end
 
+@testset "Two-sided p-values are probabilities" begin
+    # Doubling a discrete tail overshoots at `W == n(n+1)/4`, which is attainable
+    # whenever `n(n+1)/2` is even. Sweep every sign pattern of every untied sample
+    # up to n = 12; 220 of the 8190 used to come back above 1.
+    signed_ranks(n, bits) =
+        [(bits >> (i - 1)) & 1 == 1 ? float(i) : -float(i) for i in 1:n]
+    overshoots = [(n, bits) for n in 1:12 for bits in 0:(2^n - 1)
+                  if pvalue(ExactSignedRankTest(signed_ranks(n, bits))) > 1]
+    @test isempty(overshoots)
+    # the worst of them: W = 3 = 3*4/4, both tails 0.625
+    @test pvalue(ExactSignedRankTest([1.0, 2.0, -3.0])) == 1
+    # and unchanged away from the null mean
+    @test pvalue(ExactSignedRankTest([1.0, 2.0, 3.0])) ≈ 0.25
+end
+
 @testset "Exact with ties" begin
     show(IOBuffer(), ExactSignedRankTest([1:10;], [1:10;]))
 


### PR DESCRIPTION
One of the standalone pieces of #376, split out per review so each fix can be judged alone. Independent of the others; merge in any order.

`pvalue(ExactSignedRankTest([1.0, 2.0, -3.0]))` returned `1.25`. The untied branch doubled the tail on whichever side of the null mean `W` fell, without clipping; where `n(n+1)/2` is even the null mean is attainable and the doubled tail comes to `1 + P(W == mean)`. Sweeping every sign pattern of every untied sample up to `n = 12`, 220 of 8190 exceeded 1. The three neighbouring exact routes already clip; this brings the fourth into line. Nothing away from the null mean moves.
