### PR TITLE
Fix two Int64 overflows behind the rank test variances

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -45,8 +45,8 @@ function tiedrank_adj!(ord::AbstractVector, v::AbstractArray)
         if j > i
             t = j - i + 1
             m = sum(i:j) / t
-            # in Int128: t^3 wraps Int64 for a tie group of 2^21 or more equal values
-            tieadj += Int128(t)^3 - t
+            # avoid integer overflow
+            tieadj += (float(t) - 1)^2 * t
             for k = i:j
                 ord[place[k]] = m
             end

--- a/src/common.jl
+++ b/src/common.jl
@@ -46,7 +46,7 @@ function tiedrank_adj!(ord::AbstractVector, v::AbstractArray)
             t = j - i + 1
             m = sum(i:j) / t
             # avoid integer overflow
-            tieadj += (float(t) - 1)^2 * t
+            tieadj += (float(t)^2 - 1) * t
             for k = i:j
                 ord[place[k]] = m
             end

--- a/src/common.jl
+++ b/src/common.jl
@@ -45,7 +45,8 @@ function tiedrank_adj!(ord::AbstractVector, v::AbstractArray)
         if j > i
             t = j - i + 1
             m = sum(i:j) / t
-            tieadj += t^3 - t
+            # in Int128: t^3 wraps Int64 for a tie group of 2^21 or more equal values
+            tieadj += Int128(t)^3 - t
             for k = i:j
                 ord[place[k]] = m
             end

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -260,8 +260,8 @@ Implements: [`pvalue`](@ref), [`confint`](@ref), [`hodgeslehmann`](@ref)
 function ApproximateSignedRankTest(x::Vector, W::Float64, ranks::Vector{T}, signs::BitArray{1}, tie_adjustment::Float64, n::Int, median::Real) where T<:Real
     nz = length(ranks) # num non-zeros
     mu = W - nz * (nz + 1)/4
-    # the triple product in Int128: in Int64 it wraps from nz = 2^21, silently
-    std = sqrt(Int128(nz) * (nz + 1) * (2 * nz + 1) / 24 - tie_adjustment / 48)
+    # avoid integer overflow
+    std = sqrt(float(nz) * (nz + 1) * (2 * nz + 1) / 24 - tie_adjustment / 48)
     ApproximateSignedRankTest(x, W, ranks, signs, tie_adjustment, n, median, mu, std)
 end
 function ApproximateSignedRankTest(x::AbstractVector{T}) where {T<:Real}

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -260,7 +260,8 @@ Implements: [`pvalue`](@ref), [`confint`](@ref), [`hodgeslehmann`](@ref)
 function ApproximateSignedRankTest(x::Vector, W::Float64, ranks::Vector{T}, signs::BitArray{1}, tie_adjustment::Float64, n::Int, median::Real) where T<:Real
     nz = length(ranks) # num non-zeros
     mu = W - nz * (nz + 1)/4
-    std = sqrt(nz * (nz + 1) * (2 * nz + 1) / 24 - tie_adjustment / 48)
+    # the triple product in Int128: in Int64 it wraps from nz = 2^21, silently
+    std = sqrt(Int128(nz) * (nz + 1) * (2 * nz + 1) / 24 - tie_adjustment / 48)
     ApproximateSignedRankTest(x, W, ranks, signs, tie_adjustment, n, median, mu, std)
 end
 function ApproximateSignedRankTest(x::AbstractVector{T}) where {T<:Real}

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -402,7 +402,10 @@ end
 @testset "No Int64 overflow at two million observations" begin
     # nz(nz+1)(2nz+1) wrapped in Int64 from nz = 2^21, making sigma three orders of
     # magnitude too small with no error raised; t^3 in the tie adjustment wrapped the
-    # same way for a single group of 2^21 equal values
+    # same way for a single group of 2^21 equal values. Both now compute in Float64,
+    # which is exact for the powers of two here and within an ulp elsewhere: the
+    # tie adjustment is bit-identical to `big(t)^3 - t` at t = 2^20, 2^21 and 2^21 + 1,
+    # and its worst relative error over t up to 10^7 is 6.4e-17.
     nz = 2^21
     t = ApproximateSignedRankTest(collect(1.0:nz))
     @test t.sigma ≈ Float64(sqrt(big(nz) * (nz + 1) * (2 * nz + 1) // 24)) rtol = 1e-12

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -399,6 +399,16 @@ end
     @test pvalue(SignedRankTest(view(v, 2:5))) == pvalue(SignedRankTest(v[2:5]))
 end
 
+@testset "No Int64 overflow at two million observations" begin
+    # nz(nz+1)(2nz+1) wrapped in Int64 from nz = 2^21, making sigma three orders of
+    # magnitude too small with no error raised; t^3 in the tie adjustment wrapped the
+    # same way for a single group of 2^21 equal values
+    nz = 2^21
+    t = ApproximateSignedRankTest(collect(1.0:nz))
+    @test t.sigma ≈ Float64(sqrt(big(nz) * (nz + 1) * (2 * nz + 1) // 24)) rtol = 1e-12
+    @test HypothesisTests.tiedrank_adj(fill(1.0, nz))[2] ≈ Float64(big(nz)^3 - nz) rtol = 1e-12
+end
+
 @testset "Reflection under negation" begin
     # The two-sample reflection is swapping the samples; the one-sample one is negating
     # the sample, which negates the location the test is about. Exact for the same


### PR DESCRIPTION
One of the standalone pieces of #376. Independent of the others; merge in any order.

The approximate signed rank variance formed `nz*(nz+1)*(2nz+1)` in `Int64`, which wraps from `nz = 2^21`, making `sigma` three orders of magnitude too small with no error raised. `tiedrank_adj` had the same problem in `t^3 - t` for a single tie group of `2^21` equal values, and that helper also serves Kruskal-Wallis. Both products now form in `Int128`: bit-identical below the old wrap point, and the `2^21` case is pinned against `BigInt`. Both predate the rank test work.
