### PR TITLE
Accept any AbstractVector in the signed rank constructors

### DIFF
--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -53,7 +53,8 @@ Equivalently, construct [`ExactSignedRankTest`](@ref) or
 Implements: [`pvalue`](@ref), [`confint`](@ref), [`hodgeslehmann`](@ref)
 """
 function SignedRankTest(x::AbstractVector{T}; method = :auto) where T<:Real
-    (W, ranks, signs, tie_adjustment, n, median) = signedrankstats(x)
+    v = convert(Vector{T}, x)
+    (W, ranks, signs, tie_adjustment, n, median) = signedrankstats(v)
     # `ranks` covers the non-zero observations alone, so its length is that count
     n_nonzero = length(ranks)
     # the named tuple the `method` callable is documented to receive, and the automatic
@@ -62,9 +63,9 @@ function SignedRankTest(x::AbstractVector{T}; method = :auto) where T<:Real
              tie_adjustment = tie_adjustment)
     default = n_nonzero <= 15 || (n_nonzero <= 50 && tie_adjustment == 0) ? :exact : :approximate
     if resolve_rank_method(method, stats, default) === :exact
-        ExactSignedRankTest(x, W, ranks, signs, tie_adjustment, n, median)
+        ExactSignedRankTest(v, W, ranks, signs, tie_adjustment, n, median)
     else
-        ApproximateSignedRankTest(x, W, ranks, signs, tie_adjustment, n, median)
+        ApproximateSignedRankTest(v, W, ranks, signs, tie_adjustment, n, median)
     end
 end
 SignedRankTest(x::AbstractVector{T}, y::AbstractVector{S}; method = :auto) where {T<:Real,S<:Real} =
@@ -110,8 +111,10 @@ refuses rather than enumerate indefinitely, and `method = :approximate` is the w
 
 Implements: [`pvalue`](@ref), [`confint`](@ref), [`hodgeslehmann`](@ref)
 """
-ExactSignedRankTest(x::AbstractVector{T}) where {T<:Real} =
-    ExactSignedRankTest(x, signedrankstats(x)...)
+function ExactSignedRankTest(x::AbstractVector{T}) where {T<:Real}
+    v = convert(Vector{T}, x)
+    return ExactSignedRankTest(v, signedrankstats(v)...)
+end
 ExactSignedRankTest(x::AbstractVector{S}, y::AbstractVector{T}) where {S<:Real,T<:Real} =
     ExactSignedRankTest(x - y)
 
@@ -251,8 +254,10 @@ function ApproximateSignedRankTest(x::Vector, W::Float64, ranks::Vector{T}, sign
     std = sqrt(nz * (nz + 1) * (2 * nz + 1) / 24 - tie_adjustment / 48)
     ApproximateSignedRankTest(x, W, ranks, signs, tie_adjustment, n, median, mu, std)
 end
-ApproximateSignedRankTest(x::AbstractVector{T}) where {T<:Real} =
-    ApproximateSignedRankTest(x, signedrankstats(x)...)
+function ApproximateSignedRankTest(x::AbstractVector{T}) where {T<:Real}
+    v = convert(Vector{T}, x)
+    return ApproximateSignedRankTest(v, signedrankstats(v)...)
+end
 ApproximateSignedRankTest(x::AbstractVector{S}, y::AbstractVector{T}) where {S<:Real,T<:Real} =
     ApproximateSignedRankTest(x - y)
 

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -364,6 +364,17 @@ end
     @test_throws HypothesisTests.ComputationTooLarge pvalue(SignedRankTest(tied; method=:exact))
 end
 
+@testset "AbstractVector inputs" begin
+    # ranges and views used to fail with a MethodError: the structs store Vector,
+    # and nothing converted on the way in
+    @test pvalue(SignedRankTest(-2:7)) == pvalue(SignedRankTest([-2:7;]))
+    @test pvalue(ExactSignedRankTest(-2:7)) == pvalue(ExactSignedRankTest([-2:7;]))
+    @test pvalue(ApproximateSignedRankTest(1.0:20.0)) ==
+          pvalue(ApproximateSignedRankTest([1.0:20.0;]))
+    v = [1.0, -2.0, 3.0, -4.0, 5.0, 6.0]
+    @test pvalue(SignedRankTest(view(v, 2:5))) == pvalue(SignedRankTest(v[2:5]))
+end
+
 @testset "Reflection under negation" begin
     # The two-sample reflection is swapping the samples; the one-sample one is negating
     # the sample, which negates the location the test is about. Exact for the same


### PR DESCRIPTION
One of the standalone pieces of #376. Independent of the others; merge in any order.

`SignedRankTest(1:5)`, ranges, and views threw a `MethodError`: the constructors declare `AbstractVector` but passed the input straight to struct fields typed `Vector`. They convert on the way in now, as the Mann-Whitney constructors always have; the conversion is a no-op for a `Vector`. Pre-existing on `master`.
