### PR TITLE
Report both observation counts, and name the signed rank statistic in show

### DIFF
--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -94,8 +94,8 @@ end
 
 struct ExactSignedRankTest <: HypothesisTest
     vals::Vector{Float64}   # original values
-    W::Float64              # test statistic: Wilcoxon rank-sum statistic
-    ranks::Vector{Float64}           # ranks without ties (zero values)
+    W::Float64              # test statistic: the signed rank statistic W+
+    ranks::Vector{Float64}           # midranks of |d| over the non-zero observations
     signs::BitArray{1}      # signs of input of ranks
     tie_adjustment::Float64 # adjustment for ties
     n::Int                  # number of observations
@@ -130,12 +130,13 @@ population_param_of_interest(x::ExactSignedRankTest) = ("Location parameter (pse
 default_tail(test::ExactSignedRankTest) = :both
 
 function show_params(io::IO, x::ExactSignedRankTest, ident)
-    println(io, ident, "number of observations:      ", x.n)
-    println(io, ident, "Wilcoxon rank-sum statistic: ", x.W)
-    print(io, ident, "rank sums:                   ")
+    println(io, ident, "number of observations:         ", x.n)
+    println(io, ident, "non-zero observations:          ", length(x.ranks))
+    println(io, ident, "Wilcoxon signed rank statistic: ", x.W)
+    print(io, ident, "rank sums:                      ")
     show(io, [sum(x.ranks[x.signs]), sum(x.ranks[map(!, x.signs)])])
     println(io)
-    println(io, ident, "adjustment for ties:         ", x.tie_adjustment)
+    println(io, ident, "adjustment for ties:            ", x.tie_adjustment)
 end
 
 # Enumerate all possible Wilcoxon rank-sum results for a given vector, determining left-
@@ -221,8 +222,8 @@ StatsAPI.confint(x::ExactSignedRankTest; level::Real=0.95, tail=:both) =
 
 struct ApproximateSignedRankTest <: HypothesisTest
     vals::Vector{Float64}   # original values
-    W::Float64              # test statistic: Wilcoxon rank-sum statistic
-    ranks::Vector{Float64} # ranks without ties (zero values)
+    W::Float64              # test statistic: the signed rank statistic W+
+    ranks::Vector{Float64} # midranks of |d| over the non-zero observations
     signs::BitArray{1}      # signs of input of ranks
     tie_adjustment::Float64 # adjustment for ties
     n::Int                  # number of observations
@@ -276,13 +277,14 @@ population_param_of_interest(x::ApproximateSignedRankTest) = ("Location paramete
 default_tail(test::ApproximateSignedRankTest) = :both
 
 function show_params(io::IO, x::ApproximateSignedRankTest, ident)
-    println(io, ident, "number of observations:      ", x.n)
-    println(io, ident, "Wilcoxon rank-sum statistic: ", x.W)
-    print(io, ident, "rank sums:                   ")
+    println(io, ident, "number of observations:         ", x.n)
+    println(io, ident, "non-zero observations:          ", length(x.ranks))
+    println(io, ident, "Wilcoxon signed rank statistic: ", x.W)
+    print(io, ident, "rank sums:                      ")
     show(io, [sum(x.ranks[x.signs]), sum(x.ranks[map(!, x.signs)])])
     println(io)
-    println(io, ident, "adjustment for ties:         ", x.tie_adjustment)
-    println(io, ident, "normal approximation (μ, σ): ", (x.mu, x.sigma))
+    println(io, ident, "adjustment for ties:            ", x.tie_adjustment)
+    println(io, ident, "normal approximation (μ, σ):    ", (x.mu, x.sigma))
 end
 
 function StatsAPI.pvalue(x::ApproximateSignedRankTest; tail=:both)

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -21,9 +21,60 @@ Base.axes(v::ZeroBasedVector) = (Base.IdentityUnitRange(0:(length(v.data) - 1)),
 Base.getindex(v::ZeroBasedVector, i::Int) = v.data[i + 1]
 
 @testset "Wilcoxon" begin
+@testset "show output" begin
+    # A sample with zeros, so the two observation counts differ: the statistic, the
+    # p-value and the ranks describe the seven non-zero differences, while `n` counts
+    # all ten. Both are printed, and the statistic is named for the test that computes
+    # it rather than for the two-sample one.
+    d = [0.0, 1.5, -2.5, 0.0, 3.5, -0.5, 4.0, 2.2, -1.1, 0.0]
+
+    @test repr(MIME"text/plain"(), ExactSignedRankTest(d)) == """
+    Exact Wilcoxon signed rank test
+    -------------------------------
+    Population details:
+        parameter of interest:   Location parameter (pseudomedian)
+        value under h_0:         0
+        point estimate:          1.025
+        95% confidence interval: (-0.55, 2.0)
+
+    Test summary:
+        outcome with 95% confidence: fail to reject h_0
+        two-sided p-value:           0.3750
+
+    Details:
+        number of observations:         10
+        non-zero observations:          7
+        Wilcoxon signed rank statistic: 20.0
+        rank sums:                      [20.0, 8.0]
+        adjustment for ties:            0.0
+    """
+
+    # the approximate type prints one line more, the centred statistic beside sigma
+    @test repr(MIME"text/plain"(), ApproximateSignedRankTest(d)) == """
+    Approximate Wilcoxon signed rank test
+    -------------------------------------
+    Population details:
+        parameter of interest:   Location parameter (pseudomedian)
+        value under h_0:         0
+        point estimate:          1.025
+        95% confidence interval: (-0.55, 2.0)
+
+    Test summary:
+        outcome with 95% confidence: fail to reject h_0
+        two-sided p-value:           0.3525
+
+    Details:
+        number of observations:         10
+        non-zero observations:          7
+        Wilcoxon signed rank statistic: 20.0
+        rank sums:                      [20.0, 8.0]
+        adjustment for ties:            0.0
+        normal approximation (μ, σ):    (6.0, 5.91608)
+    """
+end
+
 @testset "Basic exact test" begin
     @test default_tail(ExactSignedRankTest([1:10;], [2:2:20;])) == :both
-	show(IOBuffer(), ExactSignedRankTest([1:10;], [2:2:20;]))
 
     # Two-sided
     for kwargs in ((), (; tail = :both))


### PR DESCRIPTION
One of the standalone pieces of #376. Independent of the others; merge in any order. Printed output only.

For a 20-point sample with five zero differences, `show` printed `number of observations: 20` while the statistic, p-value and ranks were computed from the other 15; both counts are now printed. And the statistic line labelled `W⁺` as `Wilcoxon rank-sum statistic`, the two-sample test's name; it now reads `Wilcoxon signed rank statistic`. Both predate the rank test work.
