### PR TITLE
State the nulls the rank tests control, and label the variances as variances

### DIFF
--- a/src/mann_whitney.jl
+++ b/src/mann_whitney.jl
@@ -30,18 +30,26 @@ export MannWhitneyUTest, ExactMannWhitneyUTest, ApproximateMannWhitneyUTest
 """
     MannWhitneyUTest(x::AbstractVector{<:Real}, y::AbstractVector{<:Real}; method = :auto)
 
-Perform a Mann-Whitney U test of the null hypothesis that the probability that an
-observation drawn from the same population as `x` is greater than an observation drawn
-from the same population as `y` is equal to the probability that an observation drawn
-from the same population as `y` is greater than an observation drawn from the same
-population as `x` against the alternative hypothesis that these probabilities are not
-equal.
+Perform a Mann-Whitney U test of the null hypothesis that `x` and `y`
+are drawn from the same distribution, against the alternative that one tends to exceed
+the other.
+
+Equality of the two distributions is what makes the test exact: it renders the pooled
+observations exchangeable, which is what the null distribution of the statistic rests on.
+This is *not* a test of `P(x > y) = P(y > x)` alone. That weaker equality permits the two
+distributions to differ in spread, and then the test does not hold its level: for
+`Normal(0, 1)` against `Normal(0, 3)` (σ = 3, so three times the spread), where it holds
+exactly, a nominal 0.05 test rejects about 13% of the time at `nx, ny = 30, 10`, and about
+1.7% at `10, 30`.
+
+Under a shift model the location estimated is the median of `x - y`, reported by
+[`hodgeslehmann`](@ref).
 
 The Mann-Whitney U test is sometimes known as the Wilcoxon rank-sum test.
 
-When there are no tied ranks and ≤50 samples, or tied ranks and ≤10 samples,
-`MannWhitneyUTest` performs an exact Mann-Whitney U test. In all other cases,
-`MannWhitneyUTest` performs an approximate Mann-Whitney U test.
+`MannWhitneyUTest` chooses between the exact and the approximate test by the tie pattern and
+the pooled sample size `nx + ny`: with no tied ranks it is exact for `nx + ny ≤ 50`, with tied
+ranks for `nx + ny ≤ 10`, and approximate above whichever of those two applies.
 
 `method` overrides that choice:
 
@@ -107,16 +115,13 @@ end
 """
     ExactMannWhitneyUTest(x::AbstractVector{<:Real}, y::AbstractVector{<:Real})
 
-Perform an exact Mann-Whitney U test of the null hypothesis that the probability that an
-observation drawn from the same population as `x` is greater than an observation drawn
-from the same population as `y` is equal to the probability that an observation drawn
-from the same population as `y` is greater than an observation drawn from the same
-population as `x` against the alternative hypothesis that these probabilities are not
-equal.
+Perform an exact Mann-Whitney U test of the null hypothesis that `x` and `y` are drawn
+from the same distribution, against the alternative that one tends to exceed the other.
+See [`MannWhitneyUTest`](@ref) on what that null does and does not assume.
 
 When there are no tied ranks, the exact p-value is computed using the `wilcoxcdf` and `wilcoxccdf`
 functions from the `StatsFuns` package. In the presence of tied ranks, a p-value is computed by exhaustive
-enumeration of permutations, which can be very slow for even moderately sized data sets.
+enumeration of the assignments of the pooled midranks to the smaller sample.
 
 The tied route is bounded by [`MAX_EXACT_ENUMERATION_N`](@ref): beyond it this test
 refuses rather than enumerate indefinitely, and `method = :approximate` is the way on.
@@ -234,24 +239,24 @@ end
 """
     ApproximateMannWhitneyUTest(x::AbstractVector{<:Real}, y::AbstractVector{<:Real})
 
-Perform an approximate Mann-Whitney U test of the null hypothesis that the probability that
-an observation drawn from the same population as `x` is greater than an observation drawn
-from the same population as `y` is equal to the probability that an observation drawn
-from the same population as `y` is greater than an observation drawn from the same
-population as `x` against the alternative hypothesis that these probabilities are not
-equal.
+Perform an approximate Mann-Whitney U test of the null hypothesis that `x` and `y` are drawn
+from the same distribution, against the alternative that one tends to exceed the other.
+See [`MannWhitneyUTest`](@ref) on what that null does and does not assume.
 
 The p-value is computed using a normal approximation to the distribution of the
-Mann-Whitney U statistic:
+Mann-Whitney U statistic, which under the null has mean and variance
 ```math
     \\begin{align*}
-        μ & = \\frac{n_x n_y}{2}\\\\
-        σ & = \\frac{n_x n_y}{12}\\left(n_x + n_y + 1 - \\frac{a}{(n_x + n_y)(n_x +
+        μ_0 & = \\frac{n_x n_y}{2}\\\\
+        σ^2 & = \\frac{n_x n_y}{12}\\left(n_x + n_y + 1 - \\frac{a}{(n_x + n_y)(n_x +
             n_y - 1)}\\right)\\\\
         a & = \\sum_{t \\in \\mathcal{T}} t^3 - t
     \\end{align*}
 ```
 where ``\\mathcal{T}`` is the set of the counts of tied values at each tied position.
+What `show` reports as `normal approximation (μ, σ)` is the pair ``(U - μ_0, σ)``: the
+statistic centred at its null mean, and the tie-corrected standard deviation, not ``μ_0``
+itself.
 
 The confidence interval inverts the same approximation, rather than the exact null
 distribution.

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -32,12 +32,18 @@ export SignedRankTest, ExactSignedRankTest, ApproximateSignedRankTest
     SignedRankTest(x::AbstractVector{<:Real}, y::AbstractVector{<:Real}; method = :auto)
 
 Perform a Wilcoxon signed rank test of the null hypothesis that the distribution of `x`
-(or the difference `x - y` if `y` is provided) has zero median against the alternative
-hypothesis that the median is non-zero.
+(or the difference `x - y` if `y` is provided) is symmetric about zero, against the
+alternative that it is not. Under a location model, where the distribution is symmetric about
+some `θ`, that is `θ = 0` against `θ ≠ 0`, with `tail = :left` and `tail = :right` giving
+`θ < 0` and `θ > 0`.
 
-When there are no tied ranks and ≤50 samples, or tied ranks and ≤15 samples,
-`SignedRankTest` performs an exact signed rank test. In all other cases,
-`SignedRankTest` performs an approximate signed rank test.
+Symmetry is what the test needs, not a zero median: against a null of zero median alone it
+does not hold its level. The location it estimates is the pseudomedian (see
+[`hodgeslehmann`](@ref)), which equals the median when the distribution is symmetric.
+
+`SignedRankTest` chooses between the exact and the approximate test by the tie pattern and
+the number `n` of non-zero observations: with no tied ranks it is exact for `n ≤ 50`, with
+tied ranks for `n ≤ 15`, and approximate above whichever of those two applies.
 
 `method` overrides that choice:
 
@@ -98,13 +104,14 @@ end
 """
     ExactSignedRankTest(x::AbstractVector{<:Real}[, y::AbstractVector{<:Real}])
 
-Perform a Wilcoxon exact signed rank U test of the null hypothesis that the distribution of
-`x` (or the difference `x - y` if `y` is provided) has zero median against the alternative
-hypothesis that the median is non-zero.
+Perform an exact Wilcoxon signed rank test of the null hypothesis that the distribution of
+`x` (or the difference `x - y` if `y` is provided) is symmetric about zero, against the
+alternative that it is not. See [`SignedRankTest`](@ref) on what that null does and does not
+assume, and on the alternatives the `tail` keyword selects.
 
 When there are no tied ranks, the exact p-value is computed using the `signrankcdf` and `signrankccdf`
 functions from the `StatsFuns` package. In the presence of tied ranks, a p-value is computed by exhaustive
-enumeration of permutations, which can be very slow for even moderately sized data sets.
+enumeration of the ``2^n`` sign assignments over the non-zero observations.
 
 The tied route is bounded by [`MAX_EXACT_ENUMERATION_N`](@ref): beyond it this test
 refuses rather than enumerate indefinitely, and `method = :approximate` is the way on.
@@ -226,20 +233,24 @@ end
 """
     ApproximateSignedRankTest(x::AbstractVector{<:Real}[, y::AbstractVector{<:Real}])
 
-Perform a Wilcoxon approximate signed rank U test of the null hypothesis that the
-distribution of `x` (or the difference `x - y` if `y` is provided) has zero median against
-the alternative hypothesis that the median is non-zero.
+Perform an approximate Wilcoxon signed rank test of the null hypothesis that the
+distribution of `x` (or the difference `x - y` if `y` is provided) is symmetric about zero,
+against the alternative that it is not. See
+[`SignedRankTest`](@ref) on what that null does and does not assume.
 
 The p-value is computed using a normal approximation to the distribution of the signed rank
-statistic:
+statistic ``W^+``, which under the null has mean and variance
 ```math
     \\begin{align*}
-        μ & = \\frac{n(n + 1)}{4}\\\\
-        σ & = \\frac{n(n + 1)(2 * n + 1)}{24} - \\frac{a}{48}\\\\
+        μ_0 & = \\frac{n(n + 1)}{4}\\\\
+        σ^2 & = \\frac{n(n + 1)(2n + 1)}{24} - \\frac{a}{48}\\\\
         a & = \\sum_{t \\in \\mathcal{T}} t^3 - t
     \\end{align*}
 ```
-where ``\\mathcal{T}`` is the set of the counts of tied values at each tied position.
+where ``\\mathcal{T}`` is the set of the counts of tied values at each tied position and
+``n`` counts the non-zero observations. What `show` reports as `normal approximation (μ, σ)`
+is the pair ``(W^+ - μ_0, σ)``: the statistic centred at its null mean, and the
+tie-corrected standard deviation, not ``μ_0`` itself.
 
 The confidence interval still inverts the exact null distribution, whichever route the
 p-value took (see #361).


### PR DESCRIPTION
One of the standalone pieces of #376. Independent of the others; merge in any order. Docstrings only; nothing computed changes.

The signed rank docstrings gave the null as a zero median, which the test does not control: over 20000 samples of `n = 20` from median-zero but asymmetric laws, a nominal 0.05 test rejects at 0.101 (`Exponential(1) - ln 2`) and 0.110 (`LogNormal(0,1) - 1`). They now say symmetry. The Mann-Whitney docstrings gave the null as `P(x > y) = P(y > x)`, which leaves the spreads free: for `Normal(0,1)` against `Normal(0,3)`, where that equality holds exactly, rejection is about 13% at `(30, 10)` and 1.7% at `(10, 30)`, in both directions, so it cannot be excused as conservative. They now say equality of distributions. Both `Approximate*` docstrings labelled their variance σ (now σ²) and presented a μ that `show` never prints; they now state the reported pair `(statistic − μ₀, σ)`.
