### PR TITLE
Flip the one-sided rank intervals to the package's own convention

### DIFF
--- a/docs/src/nonparametric.md
+++ b/docs/src/nonparametric.md
@@ -88,6 +88,12 @@ not the sample median: exact symmetry makes the two agree, but they can also agr
 coincidence, as on `[0, 2, 2, 7]`, where both are `2`. Agreement is therefore no evidence
 of symmetry.
 
+A one-sided interval keeps the endpoint that inverts the test of the same name:
+`tail = :left`, whose alternative is location below the null, gives an upper bound, and
+`tail = :right` a lower one. That is the convention of every other test here that takes a
+`tail`, and of R's `alternative = "less"` and `"greater"`. These four tests returned the
+other endpoint before this change (#368).
+
 Three named bounds apply, and past any of them the tests raise rather than run unbounded.
 The first bounds the tied-data enumeration a p-value runs, and `method = :approximate` is
 the way past it. The second bounds the set of pairwise estimates, which `confint` and

--- a/src/rank_common.jl
+++ b/src/rank_common.jl
@@ -278,6 +278,15 @@ function ci_alpha(level::Real, tail::Symbol)
     return tail === :both ? 1 - lev : 2 * (1 - lev)
 end
 
+# A one-sided interval keeps the endpoint that inverts the test of the same name, which is
+# the opposite endpoint to the one the tail is named after: the alternative `tail = :left`
+# stands for is location *below* the null, and what is compatible with that is an upper
+# bound. Eight of the nine other `confint` methods here that take a `tail` do the same, as
+# does R's `wilcox.test` under `alternative = "less"`. These four returned the other
+# endpoint until #368. `SignTest` is the ninth and is wrong twice over, both out of scope
+# here: it still returns a lower bound for `:left`, which is this same defect (#372), and
+# it caps the far side at the hypothesised median rather than leaving it infinite, so its
+# interval moves when the null moves (#369).
 function ci_from_estimates(vals::AbstractVector, k::Integer, tail::Symbol)
     m = length(vals)
     left = vals[k + 1]
@@ -285,9 +294,9 @@ function ci_from_estimates(vals::AbstractVector, k::Integer, tail::Symbol)
     if tail === :both
         return (left, right)
     elseif tail === :left
-        return (left, oftype(left, Inf))
-    else # tail === :right
         return (oftype(right, -Inf), right)
+    else # tail === :right
+        return (left, oftype(left, Inf))
     end
 end
 

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -234,9 +234,37 @@ end
     @test population_param_of_interest(ta)[3] == hodgeslehmann(ta)
     @test population_param_of_interest(ta)[3] != median(a) - median(b)
 
-    # one-sided bounds
-    @test confint(ExactMannWhitneyUTest(x, y); tail=:left)[2] == Inf
-    @test confint(ExactMannWhitneyUTest(x, y); tail=:right)[1] == -Inf
+    # one-sided bounds, on the same convention as every other test here and as R: the
+    # alternative :left names is a shift below zero, which an upper bound is compatible
+    # with (#368). R: wilcox.test(x, y, conf.int = TRUE, alternative = "less") ->
+    # (-Inf, -1.1), "greater" -> (-10.1, Inf)
+    @test all(isapprox.(confint(ExactMannWhitneyUTest(x, y); tail=:left), (-Inf, -1.1); atol=1e-8))
+    @test all(isapprox.(confint(ExactMannWhitneyUTest(x, y); tail=:right), (-10.1, Inf); atol=1e-8))
+    lo, hi = confint(ExactMannWhitneyUTest(x, y))
+    @test confint(ExactMannWhitneyUTest(x, y); tail=:left)[2] <= hi
+    @test confint(ExactMannWhitneyUTest(x, y); tail=:right)[1] >= lo
+    # R: conf.level = 0.90 -> (-10.1, -1.1)
+    @test all(isapprox.(confint(ExactMannWhitneyUTest(x, y); level=0.90), (-10.1, -1.1); atol=1e-8))
+
+    # the approximate route on the same untied sample. R with exact = FALSE,
+    # correct = TRUE: p = 0.02574808082, interval (-11.09998, -0.10008) solved
+    # numerically beside the order statistics returned here, "less" -> (-Inf, -1.10004),
+    # "greater" -> (-10.09992, Inf)
+    ma = ApproximateMannWhitneyUTest(Float64.(x), Float64.(y))
+    @test isapprox(pvalue(ma), 0.02574808082, atol=1e-9)
+    @test all(isapprox.(confint(ma), (-11.1, -0.1); atol=1e-3))
+    @test all(isapprox.(confint(ma; tail=:left), (-Inf, -1.1); atol=1e-3))
+    @test all(isapprox.(confint(ma; tail=:right), (-10.1, Inf); atol=1e-3))
+
+    # tied approximate one-sided intervals: R (approximate route, uniroot) gives
+    # (-Inf, -2.000005) and (-13.0, Inf); the order statistics land there too
+    tta = ApproximateMannWhitneyUTest(Float64.([1:10;]), Float64.([2:2:24;]))
+    @test all(isapprox.(confint(tta; tail=:left), (-Inf, -2.0); atol=1e-3))
+    @test all(isapprox.(confint(tta; tail=:right), (-13.0, Inf); atol=1e-3))
+
+    # and the 9 v 9 tied sample: R "less" -> (-Inf, 1.010023), "greater" -> (-0.098019, Inf)
+    @test all(isapprox.(confint(ta; tail=:left), (-Inf, 1.01); atol=1e-3))
+    @test all(isapprox.(confint(ta; tail=:right), (-0.098, Inf); atol=1e-3))
 
     # a narrower interval for a lower confidence level
     lo95, hi95 = confint(ExactMannWhitneyUTest(x, y); level=0.95)
@@ -375,6 +403,16 @@ end
     @test confint(MannWhitneyUTest(xs, ys; method=:exact)) isa Tuple
 end
 
+@testset "Tied exact one-sided intervals" begin
+    # under ties this route inverts the untied lattice; base R falls back to the
+    # normal approximation and lands on the same order statistics:
+    # wilcox.test(1:10, seq(2, 24, 2), conf.int = TRUE, alternative = "less") ->
+    # (-Inf, -2.000005), "greater" -> (-13.0, Inf)
+    tt = ExactMannWhitneyUTest([1:10;], [2:2:24;])
+    @test confint(tt; tail = :left) == (-Inf, -2.0)
+    @test confint(tt; tail = :right) == (-13.0, Inf)
+end
+
 @testset "Reflection under argument swap" begin
     # Swapping the samples negates the shift the test is about, so every quantity
     # carrying that sign flips and every quantity that does not is unchanged. The
@@ -409,7 +447,9 @@ end
                 @test hi_a == -lo_b
             end
             # and a lower bound becomes the negated upper bound
-            @test confint(a; tail=:left)[1] == -confint(b; tail=:right)[2]
+            # compare the finite ends: under the #368 convention `:left` is an upper
+            # bound and `:right` a lower one, so `[1]` on both would be -Inf either way
+            @test confint(a; tail=:left)[2] == -confint(b; tail=:right)[1]
         end
     end
 end

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -142,8 +142,31 @@ end
     # R with exact = FALSE gives (3.05004, 15.50001).
     @test isapprox(@inferred(confint(ApproximateSignedRankTest(x)))[1], 3.3, atol=1e-4)
     @test isapprox(@inferred(confint(ApproximateSignedRankTest(x)))[2], 15.5, atol=1e-4)
-    @test isapprox(@inferred(confint(SignedRankTest(x); tail=:left))[1], 4.45, atol=1e-4)
-    @test isapprox(@inferred(confint(SignedRankTest(x); tail=:right))[2], 14.45, atol=1e-4)
+    # one-sided, at level 0.95, is the corresponding endpoint of the two-sided 0.90
+    # interval, and the tail names the alternative: :left is location below the null, so it
+    # keeps the upper bound. R: wilcox.test(x, alternative = "less", conf.int = TRUE) ->
+    # (-Inf, 14.45), and "greater" -> (4.45, Inf). See #368.
+    @test @inferred(confint(SignedRankTest(x); tail=:left))[1] == -Inf
+    @test isapprox(@inferred(confint(SignedRankTest(x); tail=:left))[2], 14.45, atol=1e-4)
+    @test isapprox(@inferred(confint(SignedRankTest(x); tail=:right))[1], 4.45, atol=1e-4)
+    @test @inferred(confint(SignedRankTest(x); tail=:right))[2] == Inf
+    # and the pair matches what pvalue means by the same tail: the :left bound is the
+    # acceptance limit of the left-tailed test
+    u = confint(SignedRankTest(x); tail=:left)[2]
+    @test pvalue(SignedRankTest(x .- (u - 0.02)); tail=:left) > 0.05
+    @test pvalue(SignedRankTest(x .- (u + 0.02)); tail=:left) < 0.05
+    l = confint(SignedRankTest(x); tail=:right)[1]
+    @test pvalue(SignedRankTest(x .- (l + 0.02)); tail=:right) > 0.05
+    @test pvalue(SignedRankTest(x .- (l - 0.02)); tail=:right) < 0.05
+
+    # the sample from #368, all three tails against R:
+    # wilcox.test(z, conf.int = TRUE, alternative = "less")    -> (-Inf, 0.95)
+    # wilcox.test(z, conf.int = TRUE, alternative = "greater") -> (-0.45, Inf)
+    # wilcox.test(z, conf.int = TRUE)                          -> (-0.7, 1.1)
+    z = [1.2, 2.3, 3.1, 4.4, 2.8, 3.9, 5.1, 2.2, 3.3, 4.0] .- 3
+    @test all(isapprox.(confint(ExactSignedRankTest(z); tail=:left), (-Inf, 0.95); atol=1e-9))
+    @test all(isapprox.(confint(ExactSignedRankTest(z); tail=:right), (-0.45, Inf); atol=1e-9))
+    @test all(isapprox.(confint(ExactSignedRankTest(z)), (-0.7, 1.1); atol=1e-9))
 end
 
 @testset "Hodges-Lehmann estimate" begin
@@ -171,8 +194,9 @@ end
     t = SignedRankTest([1.5])
     @test confint(t) == (1.5, 1.5)
     @test confint(t; level=0.99) == (1.5, 1.5)
-    @test confint(t; tail=:left) == (1.5, Inf)
-    @test confint(t; tail=:right) == (-Inf, 1.5)
+    # `tail = :left` keeps the endpoint inverting the test of the same name (#368)
+    @test confint(t; tail=:left) == (-Inf, 1.5)
+    @test confint(t; tail=:right) == (1.5, Inf)
     @test hodgeslehmann(t) == 1.5
     @test pvalue(t) == 1.0
     @test confint(ApproximateSignedRankTest([1.5])) == (1.5, 1.5)
@@ -399,7 +423,9 @@ end
                 @test lo_a == -hi_b
                 @test hi_a == -lo_b
             end
-            @test confint(a; tail=:left)[1] == -confint(b; tail=:right)[2]
+            # compare the finite ends: under the #368 convention `:left` is an upper
+            # bound and `:right` a lower one, so `[1]` on both would be -Inf either way
+            @test confint(a; tail=:left)[2] == -confint(b; tail=:right)[1]
         end
     end
 end


### PR DESCRIPTION
One of the standalone pieces of #376. Independent of the others; merge in any order. **Breaking** for callers reading one-sided rank intervals.

Closes #368. `confint(test; tail = :left)` returned a lower bound for all four rank tests, and an upper bound for eight of the nine other `confint` methods here that take a `tail`; R returns an upper bound under `alternative = "less"`. Worse than the naming: `pvalue` and `confint` given the same tail described opposite alternatives, so a caller who picked a tail once got a mismatched pair from the rank tests and a matched one from everything else. Each tail now keeps the endpoint that inverts the test of the same name; endpoints keep their values, only which one is returned changes.

Tests assert the pairing directly, shifting the null across each endpoint and checking which one-sided p-value crosses 0.05 there, and pin all three tails against R on the sample from the issue and on tied samples through both routes. `SignTest` is the ninth and wrong twice over, out of scope here: #372 (same orientation defect) and #369 (far endpoint capped at the null).
