### PR TITLE
Report the Hodges-Lehmann estimate all four rank tests are built around

### DIFF
--- a/src/HypothesisTests.jl
+++ b/src/HypothesisTests.jl
@@ -69,26 +69,27 @@ end
 
 Base.showerror(io::IO, err::ComputationTooLarge) = print(io, "ComputationTooLarge: ", err.msg)
 
-# The interval `show` prints beside the point estimate, or `nothing` where there is none
-# to print. A test whose `confint` refuses the sample it was given still has a name, a
-# statistic and a p-value worth displaying, so the offending line is dropped rather than
-# the whole display: the rank tests bound the pairwise estimates their intervals are read
-# off (see `MAX_PAIRWISE_ESTIMATES`), and past that bound a large `MannWhitneyUTest` would
-# otherwise be impossible to look at.
+# `show` asks a test for two things it may not be able to give for the sample it was
+# handed: its point estimate and its interval. For the rank tests both are read off a
+# pairwise set bounded by `MAX_PAIRWISE_ESTIMATES`, so past that bound each raises. A
+# test that cannot afford one still has a name, a statistic and a p-value worth seeing,
+# so what cannot be computed is dropped rather than the whole display.
 #
-# Only `ComputationTooLarge` is caught. `confint` is generic over `HypothesisTest`, so
-# catching `ArgumentError` here would also swallow a genuine argument bug in any
-# downstream package's `confint` method and print a test with no interval line instead of
-# raising, which is a hard thing to debug.
-function show_confint(test::HypothesisTest)
-    applicable(confint, test) || return nothing
+# Only `ComputationTooLarge` is caught. These functions are generic over
+# `HypothesisTest`, so catching `ArgumentError` here would also swallow a genuine
+# argument bug in any downstream package's method and print a test with a line missing
+# instead of raising, which is a hard thing to debug.
+function show_or_nothing(f, test::HypothesisTest)
     try
-        return confint(test)
+        return f(test)
     catch err
         err isa ComputationTooLarge || rethrow()
         return nothing
     end
 end
+
+show_confint(test::HypothesisTest) =
+    applicable(confint, test) ? show_or_nothing(confint, test) : nothing
 
 # Pretty-print
 function Base.show(_io::IO, test::T) where T<:HypothesisTest
@@ -98,15 +99,20 @@ function Base.show(_io::IO, test::T) where T<:HypothesisTest
 
     # population details
     ci = show_confint(test)
-    (param_name, param_under_h0, param_estimate) = population_param_of_interest(test)
+    params = show_or_nothing(population_param_of_interest, test)
     println(io, "Population details:")
-    println(io, "    parameter of interest:   $param_name")
-    print(io, "    value under h_0:         ")
-    show(io, param_under_h0)
-    println(io)
-    print(io, "    point estimate:          ")
-    show(io, param_estimate)
-    println(io)
+    if params === nothing
+        println(io, "    parameter of interest:   not computed (over MAX_PAIRWISE_ESTIMATES)")
+    else
+        (param_name, param_under_h0, param_estimate) = params
+        println(io, "    parameter of interest:   $param_name")
+        print(io, "    value under h_0:         ")
+        show(io, param_under_h0)
+        println(io)
+        print(io, "    point estimate:          ")
+        show(io, param_estimate)
+        println(io)
+    end
 
     if ci !== nothing
         print(io, "    95% confidence interval: ")

--- a/src/mann_whitney.jl
+++ b/src/mann_whitney.jl
@@ -127,10 +127,7 @@ ExactMannWhitneyUTest(x::AbstractVector{S}, y::AbstractVector{T}) where {S<:Real
     ExactMannWhitneyUTest(mwustats(x, y)...)
 
 testname(::ExactMannWhitneyUTest) = "Exact Mann-Whitney U test"
-# Still the difference of sample medians, not the Hodges-Lehmann estimate the label
-# names and `confint` is built around. Changing it moves a number users see, so it
-# waits for the breaking pull request. See #363.
-population_param_of_interest(x::ExactMannWhitneyUTest) = ("Location parameter (pseudomedian)", 0, x.median) # parameter of interest: name, value under h0, point estimate
+population_param_of_interest(x::ExactMannWhitneyUTest) = ("Location shift", 0, hodgeslehmann(x)) # parameter of interest: name, value under h0, point estimate
 default_tail(test::ExactMannWhitneyUTest) = :both
 
 function show_params(io::IO, x::ExactMannWhitneyUTest, ident)
@@ -274,10 +271,7 @@ ApproximateMannWhitneyUTest(x::AbstractVector{S}, y::AbstractVector{T}) where {S
     ApproximateMannWhitneyUTest(mwustats(x, y)...)
 
 testname(::ApproximateMannWhitneyUTest) = "Approximate Mann-Whitney U test"
-# Still the difference of sample medians, not the Hodges-Lehmann estimate the label
-# names and `confint` is built around. Changing it moves a number users see, so it
-# waits for the breaking pull request. See #363.
-population_param_of_interest(x::ApproximateMannWhitneyUTest) = ("Location parameter (pseudomedian)", 0, x.median) # parameter of interest: name, value under h0, point estimate
+population_param_of_interest(x::ApproximateMannWhitneyUTest) = ("Location shift", 0, hodgeslehmann(x)) # parameter of interest: name, value under h0, point estimate
 default_tail(test::ApproximateMannWhitneyUTest) = :both
 
 function show_params(io::IO, x::ApproximateMannWhitneyUTest, ident)

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -119,9 +119,7 @@ ExactSignedRankTest(x::AbstractVector{S}, y::AbstractVector{T}) where {S<:Real,T
     ExactSignedRankTest(x - y)
 
 testname(::ExactSignedRankTest) = "Exact Wilcoxon signed rank test"
-# Still the sample median, not the Hodges-Lehmann estimate the label names and the
-# interval is built around. See #363.
-population_param_of_interest(x::ExactSignedRankTest) = ("Location parameter (pseudomedian)", 0, x.median) # parameter of interest: name, value under h0, point estimate
+population_param_of_interest(x::ExactSignedRankTest) = ("Location parameter (pseudomedian)", 0, hodgeslehmann(x)) # parameter of interest: name, value under h0, point estimate
 default_tail(test::ExactSignedRankTest) = :both
 
 function show_params(io::IO, x::ExactSignedRankTest, ident)
@@ -262,9 +260,7 @@ ApproximateSignedRankTest(x::AbstractVector{S}, y::AbstractVector{T}) where {S<:
     ApproximateSignedRankTest(x - y)
 
 testname(::ApproximateSignedRankTest) = "Approximate Wilcoxon signed rank test"
-# Still the sample median, not the Hodges-Lehmann estimate the label names and the
-# interval is built around. See #363.
-population_param_of_interest(x::ApproximateSignedRankTest) = ("Location parameter (pseudomedian)", 0, x.median) # parameter of interest: name, value under h0, point estimate
+population_param_of_interest(x::ApproximateSignedRankTest) = ("Location parameter (pseudomedian)", 0, hodgeslehmann(x)) # parameter of interest: name, value under h0, point estimate
 default_tail(test::ApproximateSignedRankTest) = :both
 
 function show_params(io::IO, x::ApproximateSignedRankTest, ident)

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -23,7 +23,7 @@ end
     Exact Mann-Whitney U test
     -------------------------
     Population details:
-        parameter of interest:   Location parameter (pseudomedian)
+        parameter of interest:   Location shift
         value under h_0:         0
         point estimate:          -5.6
         95% confidence interval: (-11.1, -0.1)
@@ -103,7 +103,7 @@ end
     Exact Mann-Whitney U test
     -------------------------
     Population details:
-        parameter of interest:   Location parameter (pseudomedian)
+        parameter of interest:   Location shift
         value under h_0:         0
         point estimate:          -7.5
         95% confidence interval: (-14.0, -1.0)
@@ -122,7 +122,7 @@ end
     Exact Mann-Whitney U test
     -------------------------
     Population details:
-        parameter of interest:   Location parameter (pseudomedian)
+        parameter of interest:   Location shift
         value under h_0:         0
         point estimate:          7.5
         95% confidence interval: (1.0, 14.0)
@@ -230,12 +230,9 @@ end
     @test all(isapprox.(confint(ta), (-0.37, 1.183); atol = 1e-4))
     @test hodgeslehmann(ta) ≈ 0.56
 
-    # PENDING #363: the reported estimate is still the difference of sample medians,
-    # not the Hodges-Lehmann estimate the "pseudomedian" label names and the interval
-    # above is built around. R reports 0.56005616 for this sample.
-    @test population_param_of_interest(ta)[3] ≈ 0.62
-    @test population_param_of_interest(ta)[3] == median(a) - median(b)
-    @test population_param_of_interest(ta)[3] != hodgeslehmann(ta)
+    # the estimate that is reported is the one the interval is built around
+    @test population_param_of_interest(ta)[3] == hodgeslehmann(ta)
+    @test population_param_of_interest(ta)[3] != median(a) - median(b)
 
     # one-sided bounds
     @test confint(ExactMannWhitneyUTest(x, y); tail=:left)[2] == Inf
@@ -347,10 +344,16 @@ end
     t = MannWhitneyUTest(collect(1.0:nx), collect(1.5:1:(ny + 0.5)))
     @test nx * ny > HypothesisTests.MAX_PAIRWISE_ESTIMATES
     @test_throws HypothesisTests.ComputationTooLarge confint(t)
+    # #363 made the reported estimate the Hodges-Lehmann one, read off the same set,
+    # so past the bound the point estimate goes the same way the interval does
+    @test_throws HypothesisTests.ComputationTooLarge hodgeslehmann(t)
     out = sprint(show, t)
     @test occursin("Approximate Mann-Whitney U test", out)
     @test occursin("two-sided p-value", out)
+    @test occursin("number of observations in each group", out)
     @test !occursin("confidence interval", out)
+    @test !occursin("point estimate", out)
+    @test occursin("not computed (over MAX_PAIRWISE_ESTIMATES)", out)
 
     # and where it can afford one it still prints it
     @test occursin("95% confidence interval",

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -154,12 +154,12 @@ end
     @test hodgeslehmann(ExactSignedRankTest(x)) == hodgeslehmann(ApproximateSignedRankTest(x))
     lo, hi = confint(ExactSignedRankTest(x))
     @test lo <= hodgeslehmann(ExactSignedRankTest(x)) <= hi
-    # PENDING #363: the reported estimate is still the sample median, not the
-    # Hodges-Lehmann estimate the "pseudomedian" label names.
-    @test population_param_of_interest(ExactSignedRankTest(x))[3] == median(x) == 10.1
-    @test population_param_of_interest(ExactSignedRankTest(x))[3] != hodgeslehmann(ExactSignedRankTest(x))
+    # the estimate that is reported is the one the interval is built around
+    @test population_param_of_interest(ExactSignedRankTest(x))[3] == hodgeslehmann(ExactSignedRankTest(x))
+    @test population_param_of_interest(ExactSignedRankTest(x))[3] != median(x)
 
-    # ties: R reports -2.1
+    # ties: R's wilcox.test reports -2.1; exactRankTests::wilcox.exact reports -2.35,
+    # which is its conditional estimator, not this one
     h = [1, 2, 3, 4, 5, 6, 7, 10, 10, 10, 10, 10, 13, 14, 15] .- 10.1
     @test hodgeslehmann(SignedRankTest(h)) ≈ -2.1
 end


### PR DESCRIPTION
One of the standalone pieces of #376. Independent of the others; merge in any order. **Breaking** for callers reading the reported estimate.

Closes #363. The label said pseudomedian while the value was `median(x)`, and the two-sample tests reported `median(x) - median(y)` under the same label; the Hodges-Lehmann estimate the interval is built around is a different quantity from either: 0.62 against 0.56 on the tied 9 v 9 Mann-Whitney sample, 10.1 against 9.675 on the fifteen-point signed rank one, R reporting the latter in both cases. All four types now report it; the Mann-Whitney label becomes `Location shift`, the two-sample estimand under the shift model.

The estimate is read off the same bounded pairwise set as the interval, so past `MAX_PAIRWISE_ESTIMATES` it raises `ComputationTooLarge` where a stored median could not; `show` treats that like a refused interval, printing `not computed` for the parameter line rather than failing to display, and only for that exception type.
