### PR TITLE
Warn when a requested confidence level is out of reach for the sample

### DIFF
--- a/src/mann_whitney.jl
+++ b/src/mann_whitney.jl
@@ -218,7 +218,7 @@ function StatsAPI.confint(x::ExactMannWhitneyUTest; level::Real=0.95, tail=:both
         "Pass `method = :approximate` for the normal-approximation interval, which " *
         "inverts a closed form and is bounded by memory alone.")
     vals = cross_differences(x.x, x.y)
-    k = exact_ci_index(length(vals), alpha, u -> wilcoxcdf(x.nx, x.ny, u))
+    k = exact_ci_index(length(vals), alpha, u -> wilcoxcdf(x.nx, x.ny, u); tail = tail)
     return ci_from_estimates(vals, k, tail)
 end
 
@@ -309,6 +309,6 @@ function StatsAPI.confint(x::ApproximateMannWhitneyUTest; level::Real=0.95, tail
     alpha = ci_alpha(level, tail)
     vals = cross_differences(x.x, x.y)
     m = length(vals)
-    k = normal_ci_index(m, m / 2, x.sigma, alpha)
+    k = normal_ci_index(m, m / 2, x.sigma, alpha; tail = tail)
     return ci_from_estimates(vals, k, tail)
 end

--- a/src/rank_common.jl
+++ b/src/rank_common.jl
@@ -221,7 +221,7 @@ function last_true(H::Integer, pred)
 end
 
 """
-    exact_ci_index(m, alpha, cdf) -> Int
+    exact_ci_index(m, alpha, cdf; tail = :both) -> Int
 
 Invert the exact null distribution conservatively: the largest `k` whose interval
 still attains at least `1 - alpha`. `cdf(k)` is the null probability of a statistic
@@ -229,14 +229,38 @@ at most `k`.
 
 This is the rule R's `wilcox.test` uses, where the lower endpoint is
 `diffs[qsignrank(alpha/2, n)]`; taking `k = qsignrank(alpha/2, n) - 1` reproduces it.
+
+Small samples cannot reach every level: the widest interval this form admits,
+`k = 0`, has coverage `1 - 2 cdf(0)`, which is `1 - 2^(1-n)` for an untied signed rank
+sample, so `0.95` is out of reach below `n = 6` and `0.99` below `n = 8`. That interval
+is still the best available and is returned, with a warning naming the coverage it
+actually has, rather than being returned as though it met the request. R returns the same
+interval, but silently: its `conf.level` attribute still claims the level that was asked
+for, and it warns only once the shortfall exceeds `alpha/2`, as at two observations
+against two.
+
+`tail` only shapes that warning: `alpha` is already the two-sided mass whichever tail
+the interval keeps, but the level a one-sided caller asked for is `1 - alpha/2`, not
+`1 - alpha`, and the coverage its single overshooting tail costs is `cdf(0)` once,
+not twice.
 """
-function exact_ci_index(m::Integer, alpha::Real, cdf)
+function exact_ci_index(m::Integer, alpha::Real, cdf; tail::Symbol = :both)
     half = alpha / 2
-    return last_true(div(m, 2), k -> cdf(k) < half)
+    p0 = cdf(0)
+    if p0 > half
+        # `1 - 2 p0` double-counts the atom at 0 when the null distribution is degenerate,
+        # so it can come out negative; the coverage is nowhere below zero.
+        sides = tail === :both ? 2 : 1
+        @warn "the requested confidence level is not attainable for a sample this small; " *
+              "returning the widest interval this construction admits" requested = 1 - sides * half attainable =
+              max(0.0, 1 - sides * p0)
+        return 0
+    end
+    return last_true(div(m - 1, 2), k -> cdf(k) < half)
 end
 
 """
-    normal_ci_index(m, mu, sigma, alpha) -> Int
+    normal_ci_index(m, mu, sigma, alpha; tail = :both) -> Int
 
 Invert the normal approximation to the null distribution, `mu` and `sigma` being its
 mean and (tie-corrected) standard deviation.
@@ -254,16 +278,35 @@ default. Dropping it makes the interval narrower than the exact one for 7 of 66 
 rank sample sizes at `level = 0.95` and 45 of 66 at `level = 0.90`; with it the interval
 is never narrower than exact at `level = 0.95` or above.
 
-Below that it can still be narrower by one order statistic, on strongly unbalanced
-designs: at `level = 0.90` that happens for 131 of the 1444 Mann-Whitney shapes with
-`nx, ny` in `3:40`, concentrated at `nx = 3`. It is the exact rule that is conservative
-there rather than this one that is loose, and coverage stays at nominal rather than
-falling below it: at `(3, 12)`, `(3, 15)` and `(3, 21)` the normal route covers `0.902`,
-`0.901` and `0.900` against the exact route's `0.932`, `0.927` and `0.919`.
+Below that it can still be narrower by one order statistic, in both procedures: at
+`level = 0.90` that happens for 10 of the 66 signed rank sizes `n = 5:70`, and for 131 of
+the 1444 Mann-Whitney shapes with `nx, ny` in `3:40`, where it concentrates on strongly
+unbalanced designs at `nx = 3`. It is the exact rule that is conservative there rather
+than this one that is loose, and coverage stays at nominal rather than falling below it:
+at `(3, 12)`, `(3, 15)` and `(3, 21)` the normal route covers `0.902`, `0.901` and
+`0.900` against the exact route's `0.932`, `0.927` and `0.919`.
+
+A negative `k` means the approximation puts the endpoint outside the pairwise estimates, so
+the widest interval available is returned instead, with a warning. The warning does not
+claim the level is unattainable, because that does not follow: at `n = 8` and `level = 0.99` this
+rule asks for `k = -1` while the exact route reaches `0.9922`, which meets the request.
+What it does mean is that the sample is too small for this route, and `method = :exact` is
+where to go.
+
+As in [`exact_ci_index`](@ref), `tail` only shapes the warning: a one-sided caller asked
+for level `1 - alpha/2`, and that is what the warning should name as the request.
 """
-function normal_ci_index(m::Integer, mu::Real, sigma::Real, alpha::Real)
+function normal_ci_index(m::Integer, mu::Real, sigma::Real, alpha::Real; tail::Symbol = :both)
     q = quantile(Normal(mu, sigma), alpha / 2)
-    return clamp(ceil(Int, q - one(q) / 2) - 1, 0, div(m, 2))
+    k = ceil(Int, q - one(q) / 2) - 1
+    if k < 0
+        sides = tail === :both ? 2 : 1
+        @warn "the normal approximation puts the interval endpoint outside the set of " *
+              "pairwise estimates for a sample this small; returning the widest interval " *
+              "it admits, which may not reach the requested level. The exact test is " *
+              "the way on" requested = 1 - sides * (alpha / 2)
+    end
+    return clamp(k, 0, div(m - 1, 2))
 end
 
 # `level`/`tail` to the two-sided alpha the index rules work in. A one-sided bound

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -425,6 +425,7 @@ end
     # the normal index rule cannot tell that mean from the centred statistic, and the
     # reflection holds either way; on a clearly shifted sample it does not, which is
     # what makes this testset detect the confusion its `confint` comment warns about.
+    warned = 0
     for (x, y) in (([1.0, 4, 6, 9, 11, 14], [2.0, 5, 7, 8, 12, 13]),   # no ties
                    ([1.0, 2, 2, 5, 5, 5, 8], [2.0, 3, 5, 5, 9, 9]),    # tied within and across
                    ([1.0, 2, 3], [10.0, 11, 12, 13]),                  # disjoint, unequal sizes
@@ -441,21 +442,26 @@ end
             @test pvalue(a; tail=:left) == pvalue(b; tail=:right)
             # the two-sided interval reflects about zero, ends exchanged
             for level in (0.90, 0.95, 0.99)
-                # the smaller designs here cannot attain the higher levels, so both
-                # routes warn. That behaviour is pinned in "Unattainable levels warn"
-                # in test/wilcoxon.jl; here it is noise over the reflection identity.
-                (lo_a, hi_a), (lo_b, hi_b) =
-                    Base.CoreLogging.with_logger(Base.CoreLogging.NullLogger()) do
-                        confint(a; level=level), confint(b; level=level)
-                    end
+                # The smallest design here cannot attain the higher levels, and both
+                # routes say so. Capture rather than silence: every record has to be
+                # one of those two warnings, naming the level actually asked for, so
+                # an unexpected message fails here instead of scrolling past.
+                logs, ((lo_a, hi_a), (lo_b, hi_b)) = Test.collect_test_logs() do
+                    confint(a; level=level), confint(b; level=level)
+                end
+                @test all(r -> r.level == Base.CoreLogging.Warn &&
+                               r.kwargs[:requested] == level, logs)
+                warned += length(logs)
                 @test lo_a == -hi_b
                 @test hi_a == -lo_b
             end
-            # and a lower bound becomes the negated upper bound
             # compare the finite ends: under the #368 convention `:left` is an upper
             # bound and `:right` a lower one, so `[1]` on both would be -Inf either way
             @test confint(a; tail=:left)[2] == -confint(b; tail=:right)[1]
         end
     end
+    # and they do fire: the 3 v 4 design, on both routes, at 0.95 and 0.99, and twice
+    # over since each iteration confints the design and its swap
+    @test warned == 8
 end
 end

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -441,8 +441,13 @@ end
             @test pvalue(a; tail=:left) == pvalue(b; tail=:right)
             # the two-sided interval reflects about zero, ends exchanged
             for level in (0.90, 0.95, 0.99)
-                lo_a, hi_a = confint(a; level=level)
-                lo_b, hi_b = confint(b; level=level)
+                # the smaller designs here cannot attain the higher levels, so both
+                # routes warn. That behaviour is pinned in "Unattainable levels warn"
+                # in test/wilcoxon.jl; here it is noise over the reflection identity.
+                (lo_a, hi_a), (lo_b, hi_b) =
+                    Base.CoreLogging.with_logger(Base.CoreLogging.NullLogger()) do
+                        confint(a; level=level), confint(b; level=level)
+                    end
                 @test lo_a == -hi_b
                 @test hi_a == -lo_b
             end

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -254,7 +254,7 @@ end
     # and through the two-sample form
     @test confint(SignedRankTest([4.0], [2.5])) == (1.5, 1.5)
     # the two-sample tests already agreed: one against one is the one difference
-    @test confint(MannWhitneyUTest([4.0], [2.5])) == (1.5, 1.5)
+    @test (@test_logs (:warn, r"not attainable") confint(MannWhitneyUTest([4.0], [2.5]))) == (1.5, 1.5)
 end
 
 @testset "Zero differences" begin
@@ -287,6 +287,20 @@ end
     @test (lo, hi) == (0.0, 1.5)
     @test !(lo <= hodgeslehmann(SignedRankTest(e)) <= hi)
     @test confint(SignedRankTest(enz)) == (1.0, 3.0)
+end
+
+@testset "Unattainable levels warn" begin
+    # The widest interval this construction admits is (V_(1), V_(m)); where even that
+    # falls short of the requested level, it is returned with a warning naming the
+    # coverage actually attained, rather than as though it met the request. Only the
+    # Mann-Whitney intervals reach these index rules today; the signed rank route
+    # still inverts through its own scan and gains the same warnings with #361.
+    # R returns (-3, -1) with an achieved conf.level attribute of 2/3, which is the
+    # attainable coverage the warning here names: 1 - 2 P(U <= 0) = 1 - 2/6
+    ci22 = @test_logs (:warn, r"not attainable") confint(ExactMannWhitneyUTest([1.0, 2.0], [3.0, 4.0]))
+    @test ci22 == (-3.0, -1.0)
+    # and no warning once the level is attainable
+    @test_logs confint(ExactMannWhitneyUTest([1.0, 2.0, 5.0, 6.0], [3.0, 4.0, 7.0, 9.0]); level = 0.9)
 end
 
 @testset "method keyword" begin

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -297,8 +297,38 @@ end
     # still inverts through its own scan and gains the same warnings with #361.
     # R returns (-3, -1) with an achieved conf.level attribute of 2/3, which is the
     # attainable coverage the warning here names: 1 - 2 P(U <= 0) = 1 - 2/6
-    ci22 = @test_logs (:warn, r"not attainable") confint(ExactMannWhitneyUTest([1.0, 2.0], [3.0, 4.0]))
+    logs, ci22 = Test.collect_test_logs() do
+        confint(ExactMannWhitneyUTest([1.0, 2.0], [3.0, 4.0]))
+    end
     @test ci22 == (-3.0, -1.0)
+    @test length(logs) == 1
+    @test logs[1].level == Base.CoreLogging.Warn
+    @test occursin("not attainable", logs[1].message)
+    # the payload is the point of the warning: what was asked for, and what this
+    # construction can actually cover, which is R's achieved conf.level attribute
+    @test logs[1].kwargs[:requested] == 0.95
+    @test logs[1].kwargs[:attainable] ≈ 1 - 2/6   # 1 - 2 P(U <= 0), to the last ulp
+
+    # a one-sided caller asked for `level`, not the two-sided `2 level - 1` the index
+    # rule works in, and only its one overshooting tail can miss
+    logs1, ci1 = Test.collect_test_logs() do
+        confint(ExactMannWhitneyUTest([1.0, 2.0], [3.0, 4.0]); tail = :left)
+    end
+    @test ci1 == (-Inf, -1.0)
+    @test length(logs1) == 1
+    @test logs1[1].kwargs[:requested] == 0.95
+    @test logs1[1].kwargs[:attainable] ≈ 1 - 1/6
+
+    # the approximate rule warns for its own, weaker reason, and claims nothing about
+    # coverage: it names the request only
+    logsa, _ = Test.collect_test_logs() do
+        confint(ApproximateMannWhitneyUTest([1.0, 2.0], [3.0, 4.0]))
+    end
+    @test length(logsa) == 1
+    @test occursin("outside the set of pairwise estimates", logsa[1].message)
+    @test logsa[1].kwargs[:requested] == 0.95
+    @test !haskey(logsa[1].kwargs, :attainable)
+
     # and no warning once the level is attainable
     @test_logs confint(ExactMannWhitneyUTest([1.0, 2.0, 5.0, 6.0], [3.0, 4.0, 7.0, 9.0]); level = 0.9)
 end


### PR DESCRIPTION
One of the standalone pieces of #376. Independent of the others; merge in any order.

An unattainable confidence level passed silently: at two observations against two, a "95% confidence interval" with coverage 2/3 was printed as though it met the request. Both index rules now warn when they fall short, naming the request and, on the exact rule, the attainable coverage; nothing fires where `P(W <= 0)` equals `alpha/2` exactly, where the widest interval attains the request. R warns only once the shortfall exceeds `alpha/2` (its `conf.level` attribute claims the requested level until then), which the tests record. The approximate rule warns for its own weaker reason, an endpoint outside the pairwise estimates, and does not claim unattainability, which does not follow from it.

A `tail` keyword shapes the warning for one-sided callers, and both rules cap the index at `div(m - 1, 2)`, so an inverted interval at even `m` is unrepresentable rather than argued away. Only the Mann-Whitney intervals reach these rules today; the signed rank route gains the same warnings when #361 routes it through them.
