### PR TITLE
Pin the rank test routes the suite could not tell apart, against R

### DIFF
--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -266,6 +266,16 @@ end
     @test all(isapprox.(confint(ta; tail=:left), (-Inf, 1.01); atol=1e-3))
     @test all(isapprox.(confint(ta; tail=:right), (-0.098, Inf); atol=1e-3))
 
+    # tied one-sided p-values against exactRankTests::wilcox.exact, which computes the
+    # same conditional distribution: "less" -> 0.0060017382, "greater" -> 0.9949199407.
+    # One-sided values are convention-free. The two-sided ones differ: doubling here
+    # (0.0120034764) against summing the far tail there (0.0118890398), and the tied
+    # two-sample conditional distribution is asymmetric, so the two need not agree.
+    tt = ExactMannWhitneyUTest([1:10;], [2:2:24;])
+    @test isapprox(pvalue(tt; tail=:left), 0.0060017382, atol=1e-9)
+    @test isapprox(pvalue(tt; tail=:right), 0.9949199407, atol=1e-9)
+    @test pvalue(tt) == 2 * pvalue(tt; tail=:left)
+
     # a narrower interval for a lower confidence level
     lo95, hi95 = confint(ExactMannWhitneyUTest(x, y); level=0.95)
     lo80, hi80 = confint(ExactMannWhitneyUTest(x, y); level=0.80)
@@ -411,6 +421,53 @@ end
     tt = ExactMannWhitneyUTest([1:10;], [2:2:24;])
     @test confint(tt; tail = :left) == (-Inf, -2.0)
     @test confint(tt; tail = :right) == (-13.0, Inf)
+end
+
+@testset "The approximate interval rule is its own rule" begin
+    # on 3 v 6 the exact and the normal index rules pick different order statistics,
+    # so these two pins hold the routes apart. R: wilcox.test(x3, y6, conf.int = TRUE)
+    # -> (-8.0, 4.9); exact = FALSE -> (-9.09992, 6.09992), whose order statistics
+    # are (-9.1, 6.1).
+    x3 = [1.1, 4.7, 8.3]
+    y6 = [2.2, 3.4, 5.6, 6.8, 9.1, 10.2]
+    @test all(isapprox.(confint(ExactMannWhitneyUTest(x3, y6)), (-8.0, 4.9); atol = 1e-8))
+    @test all(isapprox.(confint(ApproximateMannWhitneyUTest(x3, y6)), (-9.1, 6.1); atol = 1e-8))
+end
+
+@testset "Approximate one-sided p-values against R" begin
+    # R: wilcox.test(1:10, seq(2.1, 21, 2), exact = FALSE, correct = TRUE,
+    #    alternative = "less") -> 0.0128740404106, "greater" -> 0.989433035935
+    am = ApproximateMannWhitneyUTest([1:10;], [2.1:2:21;])
+    @test isapprox(@inferred(pvalue(am; tail = :left)), 0.0128740404106, atol = 1e-10)
+    @test isapprox(@inferred(pvalue(am; tail = :right)), 0.989433035935, atol = 1e-10)
+end
+
+@testset "Untied with nx > ny" begin
+    # exercises the swap onto the smaller sample on the StatsFuns route.
+    # R: wilcox.test(1:12, seq(2.5, 16.5, 2), conf.int = TRUE): W = 30,
+    # p = 0.181344764626, "less" -> 0.0906723823132, "greater" -> 0.921568627451,
+    # interval (-7.5, 1.5)
+    t = ExactMannWhitneyUTest([1:12;], [2.5:2:16.5;])
+    @test t.U == 30.0
+    @test isapprox(pvalue(t), 0.181344764626, atol = 1e-10)
+    @test isapprox(pvalue(t; tail = :left), 0.0906723823132, atol = 1e-10)
+    @test isapprox(pvalue(t; tail = :right), 0.921568627451, atol = 1e-10)
+    @test confint(t) == (-7.5, 1.5)
+end
+
+@testset "Tied auto boundary at N = 10 and 11" begin
+    xa = [1.0, 2.0, 2.0, 3.0, 7.0]
+    ya = [2.0, 4.0, 5.0, 6.0, 8.0]                   # N = 10, tied: still exact
+    @test MannWhitneyUTest(xa, ya) isa ExactMannWhitneyUTest
+    @test MannWhitneyUTest(xa, [ya; 9.0]) isa ApproximateMannWhitneyUTest
+end
+
+@testset "All-equal samples" begin
+    # R: exactRankTests::wilcox.exact(rep(1, 4), rep(1, 5)) -> p = 1
+    @test pvalue(ExactMannWhitneyUTest(ones(4), ones(5))) == 1
+    # mu and sigma are both zero here, which is its own branch of the normal route
+    @test pvalue(ApproximateMannWhitneyUTest(ones(4), ones(5))) == 1
+    @test pvalue(ApproximateMannWhitneyUTest(ones(4), ones(5)); tail = :left) == 1
 end
 
 @testset "Reflection under argument swap" begin

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -108,7 +108,9 @@ end
 
 @testset "Tests for automatic selection" begin
     @test abs(@inferred(pvalue(SignedRankTest([1:10;], [2:2:20;]))) - 0.0020) <= 1e-4
-    @test abs(@inferred(pvalue(SignedRankTest([1:10;], [2:11;]))) - 0.0020) <= 1e-4
+    # 2/2^10 exactly, from the tied enumeration; the approximate route gives
+    # 0.0019042, which an atol of 1e-4 against 0.0020 would also have accepted
+    @test @inferred(pvalue(SignedRankTest([1:10;], [2:11;]))) == 0.001953125
 	@test default_tail(SignedRankTest([1:10;], [2:2:20;])) == :both
 	show(IOBuffer(), SignedRankTest([1:10;], [2:2:20;]))
 end
@@ -167,6 +169,23 @@ end
     @test all(isapprox.(confint(ExactSignedRankTest(z); tail=:left), (-Inf, 0.95); atol=1e-9))
     @test all(isapprox.(confint(ExactSignedRankTest(z); tail=:right), (-0.45, Inf); atol=1e-9))
     @test all(isapprox.(confint(ExactSignedRankTest(z)), (-0.7, 1.1); atol=1e-9))
+end
+
+@testset "Tied one-sided p-values against exactRankTests" begin
+    # R's exactRankTests::wilcox.exact computes the same conditional distribution as the
+    # tied enumeration here. Its one-sided p-values are convention-free and pin ours
+    # exactly; its two-sided can differ from doubling only where the conditional
+    # distribution is asymmetric, which the sign-flip symmetry rules out one-sample.
+    h = [1, 2, 3, 4, 5, 6, 7, 10, 10, 10, 10, 10, 13, 14, 15] .- 10.1
+    # wilcox.exact(h): 0.04052734375; "less": 0.02026367188; "greater": 0.9828491211
+    @test pvalue(ExactSignedRankTest(h)) == 0.04052734375
+    @test isapprox(pvalue(ExactSignedRankTest(h); tail=:left), 0.02026367188, atol=1e-9)
+    @test isapprox(pvalue(ExactSignedRankTest(h); tail=:right), 0.9828491211, atol=1e-9)
+    # with zeros as well as ties; wilcox.exact drops the zeros likewise
+    # wilcox.exact(d): 0.3071899414; "less": 0.8592834473; "greater": 0.1535949707
+    d = [0, 0, 0, 0.5, 0.5, 1, -0.5, -1, 1.5, -1.5, 0.5, 0, 1, -0.5, 2, 0, 0.5, -1, 1, 0.5]
+    @test isapprox(pvalue(SignedRankTest(d); tail=:left), 0.8592834473, atol=1e-9)
+    @test isapprox(pvalue(SignedRankTest(d); tail=:right), 0.1535949707, atol=1e-9)
 end
 
 @testset "Hodges-Lehmann estimate" begin
@@ -397,6 +416,24 @@ end
           pvalue(ApproximateSignedRankTest([1.0:20.0;]))
     v = [1.0, -2.0, 3.0, -4.0, 5.0, 6.0]
     @test pvalue(SignedRankTest(view(v, 2:5))) == pvalue(SignedRankTest(v[2:5]))
+end
+
+@testset "Auto boundaries at n = 50 and 51, against R" begin
+    s50 = quantile.(Normal(), (1:50) ./ 51) .+ 0.3
+    s51 = quantile.(Normal(), (1:51) ./ 52) .+ 0.3
+    @test SignedRankTest(s50) isa ExactSignedRankTest
+    @test SignedRankTest(s51) isa ApproximateSignedRankTest
+    # R switches at n < 50, so its exact side must be forced to compare:
+    # wilcox.test(qnorm((1:50)/51) + 0.3, exact = TRUE)  -> 0.0371666050798
+    # wilcox.test(qnorm((1:51)/52) + 0.3, exact = FALSE) -> 0.0345394645593
+    @test isapprox(pvalue(SignedRankTest(s50)), 0.0371666050798, atol = 1e-10)
+    @test isapprox(pvalue(SignedRankTest(s51)), 0.0345394645593, atol = 1e-10)
+end
+
+@testset "Tied auto boundary counts non-zero observations" begin
+    tied16 = repeat([1.0, -1.0, 2.5, 3.5], 4)        # 16 non-zero, tied
+    @test SignedRankTest(tied16) isa ApproximateSignedRankTest
+    @test SignedRankTest(tied16[1:15]) isa ExactSignedRankTest
 end
 
 @testset "Reflection under negation" begin


### PR DESCRIPTION
One of the standalone pieces of #376. Test-only: every pin records behaviour the package already has, against R's `wilcox.test` or `exactRankTests::wilcox.exact`, so routes the suite could not tell apart each get a value of their own. Merge in any order.

Tied one-sided p-values of both tests against `wilcox.exact` to nine digits, with the doubling-versus-far-tail convention difference recorded where two-sided values part ways; a 3 v 6 sample on which the exact and approximate Mann-Whitney interval rules pick different order statistics; the continuity-corrected one-sided approximate p-values; a 12 v 8 untied sample through the `nx > ny` swap; the automatic rule's boundaries (`n = 50/51` against R, tied 15/16 and 10/11 by type); all-equal samples returning `p = 1` on both routes. One loose tolerance is tightened to the exact enumeration value it was hiding.
