### PR TITLE
Re-measure the exact interval bound against the bisection that replaced the scan

### DIFF
--- a/docs/src/nonparametric.md
+++ b/docs/src/nonparametric.md
@@ -107,8 +107,9 @@ The first bounds the tied-data enumeration a p-value runs, and `method = :approx
 the way past it. The second bounds the set of pairwise estimates, which `confint` and
 `hodgeslehmann` form whichever route the p-value took, so `method` is no help there; it is a
 bound on memory, which is all the approximate interval spends. The third bounds the exact
-interval, which spends time as well, a lattice recursion for every candidate endpoint it
-considers, and so is bounded far below the second.
+Mann-Whitney interval, which spends time as well, a two-sample lattice recursion per
+bisection step, and so is bounded below the second; the exact signed rank interval bisects
+a cheaper recursion and meets only the second.
 
 All three raise `ComputationTooLarge`, which is its own type rather than an `ArgumentError`
 so that `show` can drop a refused interval line without also hiding real errors.

--- a/src/rank_common.jl
+++ b/src/rank_common.jl
@@ -115,9 +115,10 @@ See #7 and #97.
 
 The bound is on memory alone, which is what the approximate routes spend: forming this many
 estimates costs about 8 MB, and sorting them about that again. It admits a signed rank
-sample of roughly 1400 observations and a two-sample design of 1000 against 1000. The exact
-routes spend time as well, and are bounded far below this by
-[`MAX_EXACT_CI_ESTIMATES`](@ref).
+sample of roughly 1400 observations and a two-sample design of 1000 against 1000. The
+two-sample exact interval spends time as well and carries its own bound below this,
+[`MAX_EXACT_CI_ESTIMATES`](@ref); the one-sample exact interval bisects a cheap enough
+recursion that this bound is the only one it meets, about 6 s at the boundary.
 """
 const MAX_PAIRWISE_ESTIMATES = 1_000_000
 
@@ -130,28 +131,32 @@ function check_estimate_count(m::Integer, what::AbstractString)
 end
 
 """
-Largest set of pairwise estimates whose *exact* interval will be inverted.
+Largest set of pairwise estimates whose *exact Mann-Whitney* interval will be inverted.
 
-Selecting an endpoint from the exact null distribution costs a lattice recursion for every
-candidate it considers, so this route spends time where the approximate one spends only the
-memory [`MAX_PAIRWISE_ESTIMATES`](@ref) bounds, and it needs a bound of its own, far below.
-Past this one the exact interval is refused; the approximate interval, where the test has
-one, is not.
+Selecting an endpoint from the exact null distribution runs a lattice recursion per
+bisection step, and the two-sample recursion (`wilcoxcdf`) is the expensive one: at this
+bound, a 300-against-300 design, the interval takes about 11 s, from 0.6 s at 158 against
+158, and it grows steeply past it, 35 s at 400 against 400 and 93 s at 500 against 500.
+Past this bound the exact interval is refused; the approximate interval, which inverts a
+closed form, is not.
 
-Sized by the slower of the two procedures. The signed rank interval scans every candidate,
-``m/2`` recursions, and at the bound, a sample of 223, takes about 9 s; the two-sample
-interval bisects instead, about ``\\log_2(m/2)`` of them, and takes under a second at the
-same point. The scan grows steeply past it: a signed rank sample of 250 takes 16 s, one of
-300 takes 39 s, and one of 400 does not finish.
+The one-sample recursion (`signrankcdf`) is cheap enough that the signed rank interval
+carries no time bound at all: it reaches the memory bound
+[`MAX_PAIRWISE_ESTIMATES`](@ref), a sample of 1413, in about 6 s in total.
+
+The number was first 25\\_000, sized against the ``m/2``-recursion endpoint scan that
+inverted the signed rank interval before #361. The bisection that replaced that scan moved
+the cost from the one-sample route to the two-sample one, and the same wall-clock ceiling,
+re-measured, sits at 90\\_000.
 """
-const MAX_EXACT_CI_ESTIMATES = 25_000
+const MAX_EXACT_CI_ESTIMATES = 90_000
 
 function check_exact_ci_cost(m::Integer, escape::AbstractString)
     m <= MAX_EXACT_CI_ESTIMATES && return nothing
     throw(ComputationTooLarge(
         "refusing to invert the exact null distribution over $m pairwise estimates: more " *
-        "than MAX_EXACT_CI_ESTIMATES = $MAX_EXACT_CI_ESTIMATES. Choosing an endpoint costs " *
-        "a lattice recursion per candidate, so this route is bounded well below " *
+        "than MAX_EXACT_CI_ESTIMATES = $MAX_EXACT_CI_ESTIMATES. Choosing an endpoint runs " *
+        "a two-sample lattice recursion per bisection step, so this route is bounded below " *
         "MAX_PAIRWISE_ESTIMATES = $MAX_PAIRWISE_ESTIMATES, which bounds memory alone. " *
         escape))
 end

--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -218,12 +218,12 @@ hodgeslehmann(x::ExactSignedRankTest) = median(signedrank_pairwise_estimates(x.v
 function StatsAPI.confint(x::ExactSignedRankTest; level::Real=0.95, tail=:both)
     alpha = ci_alpha(level, tail)
     n = length(x.ranks)
+    # No time bound here, where the scan this bisection replaced carried
+    # MAX_EXACT_CI_ESTIMATES: `signrankcdf` per step is cheap enough that the memory
+    # bound inside `walsh_averages` is the one this route meets, about 6 s in total at
+    # its boundary, a sample of 1413. The two-sample route runs `wilcoxcdf` instead,
+    # which is the expensive recursion, and keeps that bound.
     vals = signedrank_pairwise_estimates(x.vals)
-    # this route still inverts the exact distribution, a lattice recursion per candidate
-    # endpoint, so it keeps the bound the scan it replaces was given
-    check_exact_ci_cost(length(vals),
-        "Pass `method = :approximate` for the normal-approximation interval, which " *
-        "inverts a closed form and is bounded by memory alone.")
     k = exact_ci_index(length(vals), alpha, i -> signrankcdf(n, i); tail = tail)
     return ci_from_estimates(vals, k, tail)
 end

--- a/test/mann_whitney.jl
+++ b/test/mann_whitney.jl
@@ -399,11 +399,20 @@ end
 end
 
 @testset "The exact interval is bounded in time" begin
-    # `exact_ci_index` runs a lattice recursion per candidate endpoint, which `:auto` never
-    # reached, since it leaves the exact route at nx + ny > 50. `method = :exact` does reach
-    # it at any size, so the interval is bounded rather than left to run.
-    x = collect(1.0:200); y = collect(1.5:1:200.5)
-    @test 200 * 200 > HypothesisTests.MAX_EXACT_CI_ESTIMATES
+    # `exact_ci_index` runs a `wilcoxcdf` lattice recursion per bisection step, which
+    # `:auto` never reaches, since it leaves the exact route at nx + ny > 50.
+    # `method = :exact` does reach it at any size, so the interval is bounded rather than
+    # left to run: about 11 s at the bound, a 300-against-300 design, 35 s at 400 against
+    # 400 and 93 s at 500 against 500. This is the only route the bound reaches; the
+    # signed rank bisection is cheap enough to run to its memory bound (test/wilcoxon.jl).
+    @test HypothesisTests.MAX_EXACT_CI_ESTIMATES == 90_000
+    @test HypothesisTests.MAX_EXACT_CI_ESTIMATES < HypothesisTests.MAX_PAIRWISE_ESTIMATES
+    @test HypothesisTests.check_exact_ci_cost(90_000, "") === nothing
+    @test_throws HypothesisTests.ComputationTooLarge HypothesisTests.check_exact_ci_cost(90_001, "")
+
+    x = collect(1.0:400); y = collect(1.5:1:400.5)
+    @test 400 * 400 > HypothesisTests.MAX_EXACT_CI_ESTIMATES
+    # refused before the differences are formed, so the refusal is immediate
     @test_throws HypothesisTests.ComputationTooLarge confint(MannWhitneyUTest(x, y; method=:exact))
     # the approximate interval inverts a closed form, so it is unaffected
     @test confint(MannWhitneyUTest(x, y; method=:approximate)) isa Tuple

--- a/test/wilcoxon.jl
+++ b/test/wilcoxon.jl
@@ -525,20 +525,15 @@ end
     @test HypothesisTests.rank_binomial(10^6, 10^6) === nothing
     @test_throws HypothesisTests.ComputationTooLarge HypothesisTests.check_exact_enumeration(10^6, 10^6)
 
-    # the exact interval is bounded separately and far lower, because choosing an endpoint
-    # costs a lattice recursion per candidate rather than a slot in an array
-    @test HypothesisTests.MAX_EXACT_CI_ESTIMATES == 25_000
-    @test HypothesisTests.MAX_EXACT_CI_ESTIMATES < HypothesisTests.MAX_PAIRWISE_ESTIMATES
-    @test HypothesisTests.check_exact_ci_cost(25_000, "") === nothing
-    @test_throws HypothesisTests.ComputationTooLarge HypothesisTests.check_exact_ci_cost(25_001, "")
-
-    # the scan is what #97 describes, and it is reached by both signed rank types, since
-    # neither has an approximate interval yet. n = 300 forms m = 45,150 Walsh averages,
-    # small enough to materialise, so this refusal is check_exact_ci_cost itself,
-    # reached through `confint`
-    @test_throws HypothesisTests.ComputationTooLarge confint(ExactSignedRankTest(collect(1.0:300)))
-    # while n = 2000, the size #97 reports hanging, is stopped a check earlier, by the
-    # memory bound on materialising the set at all
+    # The signed rank exact interval carries no time bound of its own: the bisection is
+    # cheap enough that the memory bound above is the one it meets. n = 300 forms
+    # m = 45,150 Walsh averages and inverts in about 0.04 s, where the m/2-recursion
+    # scan this replaced took 39 s and was refused past n = 223.
+    # MAX_EXACT_CI_ESTIMATES bounds the two-sample route alone now; its boundary is
+    # asserted in test/mann_whitney.jl.
+    @test confint(ExactSignedRankTest(collect(1.0:300))) isa Tuple
+    # n = 2000, the size #97 reports hanging, is stopped by the memory bound on
+    # materialising the set at all
     big = SignedRankTest(collect(1.0:2000))
     @test_throws HypothesisTests.ComputationTooLarge confint(big)
     # the test is still printable, without its interval line


### PR DESCRIPTION
The last piece of the rank test work, and the only part of it that is not a bug fix. **Nothing that computes today stops computing:** this PR only ever permits more, so it is not breaking in either direction.

## Why the bound needs re-measuring at all

`MAX_EXACT_CI_ESTIMATES = 25_000` was sized honestly, against the code that existed when it was written: the `m/2`-recursion endpoint scan that inverted the signed rank interval, which took about 9 s at the bound (a sample of 223). #361 deleted that scan and replaced it with an `O(log m)` bisection. So the constant is now calibrated against code that is no longer in the package.

The re-measurement turns up something more useful than a bigger number. The cost has **moved between the two procedures**, because the bisection made the number of recursions small and left their individual price as the only thing that matters, and the two prices are nothing like each other:

```
one signrankcdf(n = 300, ·)      1.7 ms
one wilcoxcdf(300, 300, ·)     218.5 ms      130x
```

Both routes now take about 15 bisection steps. One route pays 1.7 ms a step, the other 219 ms. A single bound over both was the right shape when they shared a scan; it is the wrong shape now.

## Measured on master

| route | size | `m` | seconds |
|:---|:---|---:|---:|
| signed rank | n = 300 | 45,150 | 0.04 |
| signed rank | n = 1000 | 500,500 | 2.1 |
| signed rank | n = 1413 | 998,991 | **6.3** (the memory bound) |
| Mann-Whitney | 158 v 158 | 24,964 | 0.61 |
| Mann-Whitney | 300 v 300 | 90,000 | **11** |
| Mann-Whitney | 400 v 400 | 160,000 | 35 |
| Mann-Whitney | 500 v 500 | 250,000 | 93 |

The criterion is the one the original bound expressed: a ceiling of roughly ten seconds on a deliberate `method = :exact` call. Applied per route, that gives two different answers.

**The signed rank interval sheds the time bound entirely.** Running it to the *memory* bound costs 6.3 s in total, already under the ceiling, so `MAX_PAIRWISE_ESTIMATES` is the only bound that route can meet and a second one buys nothing.

**The Mann-Whitney interval keeps it, at 90_000.** That admits 300 against 300 at 11 s and refuses 400 against 400, checked on `nx * ny` before the differences are formed, so an oversized request is declined rather than paid for first. The 500-against-500 row is the argument for keeping any bound here at all: without one, a `method = :exact` call runs for a minute and a half. `method = :approximate` remains the escape and is unbounded in time.

## What changes for a caller

Every one of these raises `ComputationTooLarge` on `master` today:

```julia
confint(MannWhitneyUTest(x, y; method = :exact))     # 200 v 200 → 1.8 s now
confint(MannWhitneyUTest(x, y; method = :exact))     # 300 v 300 → 10.9 s now
confint(ExactSignedRankTest(collect(1.0:300)))       # → 0.04 s now
confint(ExactSignedRankTest(collect(1.0:1000)))      # → 2.1 s now
```

400 against 400 still refuses, as it should. The refusal band #367 documented and apologised for, signed rank samples of 224 up to 1413, closes completely.

## Moving in step

The constant's docstring, the `MAX_PAIRWISE_ESTIMATES` cross-reference that pointed at it, and the manual's three-bounds paragraph all now say which route each bound governs. The boundary assertions move to `test/mann_whitney.jl`, since that is the only route the bound reaches; `test/wilcoxon.jl` asserts instead that the signed rank interval computes where it used to be refused.

Verified locally: full suite green (Wilcoxon 450, Mann-Whitney 339), doc build clean. With this in, the rank tests are complete for 0.12.0.
