### PR TITLE
Allow StatsFuns 1.5.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,6 @@
 name = "HypothesisTests"
 uuid = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
-# Deliberately not 0.12.0 yet. This branch is breaking and 0.12.0 is what it will
-# be, but the bump lands with the stacked PR, so nothing between the two can be
-# registered by accident: 0.11.8 is already in General against a different hash,
-# so the registrator refuses it.
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
@@ -27,7 +23,7 @@ StableRNGs = "1"
 Statistics = "1"
 StatsAPI = "1.6"
 StatsBase = "0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33, 0.34"
-StatsFuns = "2.2.1"
+StatsFuns = "1.5.3, 2.2.1"
 Test = "<0.0.1, 1"
 julia = "1.10"
 


### PR DESCRIPTION
This patch release of StatsFuns includes a backport of https://github.com/JuliaStats/StatsFuns.jl/pull/221