### PR TITLE
Avoid Int32 overflow in ApproximateSignedRankTest on 32-bit

### DIFF
--- a/src/wilcoxon.jl
+++ b/src/wilcoxon.jl
@@ -273,7 +273,9 @@ function ApproximateSignedRankTest(x::Vector, W::Float64, ranks::Vector{T}, sign
     nz = length(ranks) # num non-zeros
     mu = W - nz * (nz + 1)/4
     # avoid integer overflow
-    std = sqrt(float(nz) * (nz + 1) * (2 * nz + 1) / 24 - tie_adjustment / 48)
+    # Promote every factor to Float64 before multiplying so Int32 (i686) cannot overflow
+    # nz*(nz+1)*(2nz+1) for nz ≳ 1290.
+    std = sqrt(float(nz) * float(nz + 1) * float(2 * nz + 1) / 24 - tie_adjustment / 48)
     ApproximateSignedRankTest(x, W, ranks, signs, tie_adjustment, n, median, mu, std)
 end
 function ApproximateSignedRankTest(x::AbstractVector{T}) where {T<:Real}


### PR DESCRIPTION
## Summary
- `sqrt(float(nz) * (nz + 1) * (2 * nz + 1) / 24 - …)` still multiplies Int32 factors on i686; for moderate `nz` the product overflows to a negative value and `sqrt` throws `DomainError`.
- Promote each factor with `float(...)`.

Seen from QuasiMonteCarlo.jl x86 CI (`SignedRankTest` on n=20_000 samples).

## Test plan
- [ ] Existing tests green
- [ ] `ApproximateSignedRankTest(randn(20_000))` on i686 does not DomainError

Made with [Cursor](https://cursor.com)