### PR TITLE
Add 32-bit Linux CI job and fix 32-bit failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           (needs.test.result != 'success') ||
           (needs.docs.result != 'success')
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -33,6 +33,12 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
+        arch:
+          - default
+        include:
+          - version: '1'
+            os: ubuntu-latest
+            arch: x86
     # needed to allow julia-actions/cache to delete old caches that it has created
     permissions:
       actions: write
@@ -42,6 +48,7 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HypothesisTests"
 uuid = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
-version = "0.12.1"
+version = "0.12.2"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/anderson_darling.jl
+++ b/src/anderson_darling.jl
@@ -304,7 +304,7 @@ function a2_ksample(samples, modified, method)
     b = (2*g - 4)*k^2 + 8*h*k + (2*g - 14*h - 4)*H - 8*h + 4*g - 6
     c = (6*h + 2*g - 2)*k^2 + (4*h - 4*g + 6)*k + (2*h - 6)*H + 4*h
     d = (2*h + 6)*k^2 - 4*h*k
-    σ² = (a*N^3 + b*N^2 + c*N + d) / ((N - 1.) * (N - 2.) * (N - 3.))
+    σ² = (((a*N + b)*N + c)*N + d) / ((N - 1.) * (N - 2.) * (N - 3.))
 
     KSampleADTest(k, N, sqrt(σ²), (modified ? A²km : A²k), modified, method, pooled, [n...])
 end

--- a/src/power_divergence.jl
+++ b/src/power_divergence.jl
@@ -10,9 +10,9 @@ struct PowerDivergenceTest <: HypothesisTest
     lambda::Float64
     theta0::Vector{Float64}
     stat::Float64
-    df::Int64
-    observed::Matrix{Int64}
-    n::Int64
+    df::Int
+    observed::Matrix{Int}
+    n::Int
     thetahat::Vector{Float64}
 
     expected::Matrix{Float64}
@@ -67,7 +67,7 @@ one of the following methods. Possible values for `method` are:
 """
 function StatsAPI.confint(x::PowerDivergenceTest; level::Float64=0.95,
                           tail::Symbol=:both, method::Symbol=:auto, correct::Bool=true,
-                          bootstrap_iters::Int64=10000, GC::Bool=true)
+                          bootstrap_iters::Int=10000, GC::Bool=true)
     check_level(level)
 
     m  = length(x.thetahat)
@@ -99,7 +99,7 @@ function StatsAPI.confint(x::PowerDivergenceTest; level::Float64=0.95,
 end
 
 # Bootstrap
-function ci_bootstrap(x::PowerDivergenceTest,alpha::Float64, iters::Int64)
+function ci_bootstrap(x::PowerDivergenceTest,alpha::Float64, iters::Int)
     m = mapslices(x -> quantile(x, [alpha / 2, 1 - alpha / 2]), rand(Multinomial(x.n, convert(Vector{Float64}, x.thetahat)),iters) / x.n, dims=2)
     Tuple{Float64,Float64}[(boundproportion(m[i,1]), boundproportion(m[i,2])) for i in 1:length(x.thetahat)]
 end

--- a/src/power_divergence.jl
+++ b/src/power_divergence.jl
@@ -141,7 +141,7 @@ function ci_sison_glaz(x::PowerDivergenceTest, alpha::Float64; skew_correct::Boo
     for _c in 1:x.n
         #run truncpoi
         for i in 1:k
-            lambda = x.observed[i]
+            lambda = float(x.observed[i])
             #run moments
             a = lambda + _c
             b = max(lambda - _c, 0)
@@ -297,7 +297,7 @@ function PowerDivergenceTest(x::AbstractMatrix{T}; lambda::U=1.0, theta0::Vector
         colsums = sum(x, dims=1)
         df = (nrows - 1) * (ncols - 1)
         thetahat = x ./ n
-        xhat = rowsums * colsums / n
+        xhat = rowsums .* (colsums ./ n)
         theta0 = xhat / n
         V = Float64[(colsums[j]/n) * (rowsums[i]/n) * (1 - rowsums[i]/n) * (n - colsums[j]) for i in 1:nrows, j in 1:ncols]
     elseif nrows == 1 || ncols == 1


### PR DESCRIPTION
Adds one matrix entry that runs the latest stable Julia 1.x as an i686 build on the x64 `ubuntu-latest` runner, via `arch: x86` in `julia-actions/setup-julia`. GitHub has no native 32-bit runners, but 32-bit Julia runs fine on the 64-bit Linux and Windows images, and this is the cheapest way to catch `Int32` sizing and overflow bugs.

The existing nine jobs are unchanged: they get `arch: default`, which is the action's own default and resolves to the runner's native architecture. The job name now includes the arch so the new entry is distinguishable in the checks list.

The new job caught several 32-bit bugs, fixed here:

- **`KSampleADTest` (#244).** In `a2_ksample` the variance polynomial evaluates `N^3` in `Int32` before the `Float64` coefficient enters, so for a pooled sample above 1290 it wraps negative and `sqrt(σ²)` throws a `DomainError`. The polynomial is now evaluated in Horner form so every product starts from a `Float64` coefficient.
- **`PowerDivergenceTest` dispatch.** Struct fields and the `bootstrap_iters` keyword were annotated `Int64`, so on 32-bit the `Int32` default and the `Int32` values from `length` and `count` failed to dispatch. They are now `Int`.
- **`PowerDivergenceTest` overflow.** Sison-Glaz raised the integer cell count to the fourth power before the `Float64` factor entered, wrapping for counts above 215; the count is now converted to `Float64` first. The constructor formed the integer outer product `rowsums * colsums` before dividing by `n`, wrapping for the #43 table; it is now the broadcast `rowsums .* (colsums ./ n)`.

Bumps the version to 0.12.2.

Fixes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)