### PR TITLE
Print scalar test details through the compact IO context

### DIFF
--- a/docs/src/specs/t_test.md
+++ b/docs/src/specs/t_test.md
@@ -210,9 +210,9 @@ Test summary:
 
 Details:
     number of observations:   10
-    t-statistic:              3.2836227276929635
+    t-statistic:              3.28362
     degrees of freedom:       9
-    empirical standard error: 0.1674979270186815
+    empirical standard error: 0.167498
 
 
 julia> pvalue(t)
@@ -262,9 +262,9 @@ Test summary:
 
 Details:
     number of observations:   [10,8]
-    t-statistic:              2.9038471071017558
+    t-statistic:              2.90385
     degrees of freedom:       16
-    empirical standard error: 0.210927083076119
+    empirical standard error: 0.210927
 
 
 julia> confint(t)
@@ -299,9 +299,9 @@ Test summary:
 
 Details:
     number of observations:   [10,8]
-    t-statistic:              3.0833130203886516
-    degrees of freedom:       14.684901529359335
-    empirical standard error: 0.19864995735100363
+    t-statistic:              3.08331
+    degrees of freedom:       14.6849
+    empirical standard error: 0.19865
 
 
 julia> confint(t)
@@ -351,9 +351,9 @@ Test summary:
 
 Details:
     number of observations:   10
-    t-statistic:              11.75894243853277
+    t-statistic:              11.7589
     degrees of freedom:       9
-    empirical standard error: 0.022110831935702693
+    empirical standard error: 0.0221108
 
 
 julia> confint(t)

--- a/src/anderson_darling.jl
+++ b/src/anderson_darling.jl
@@ -45,10 +45,10 @@ testname(::OneSampleADTest) = "One sample Anderson-Darling test"
 default_tail(test::OneSampleADTest) = :right
 
 function show_params(io::IO, x::OneSampleADTest, ident = "")
-    println(io, ident, "number of observations:   $(x.n)")
-    println(io, ident, "sample mean:              $(x.μ)")
-    println(io, ident, "sample SD:                $(x.σ)")
-    println(io, ident, "A² statistic:             $(x.A²)")
+    println(io, ident, "number of observations:   ", x.n)
+    println(io, ident, "sample mean:              ", x.μ)
+    println(io, ident, "sample SD:                ", x.σ)
+    println(io, ident, "A² statistic:             ", x.A²)
 end
 
 ### G. and J. Marsaglia, "Evaluating the Anderson-Darling Distribution", Journal of Statistical Software, 2004
@@ -120,14 +120,14 @@ testname(::KSampleADTest) = "k-sample Anderson-Darling test"
 default_tail(test::KSampleADTest) = :right
 
 function show_params(io::IO, x::KSampleADTest, ident = "")
-    println(io, ident, "number of samples:        $(x.k)")
-    println(io, ident, "number of observations:   $(x.n)")
-    println(io, ident, "SD of A²k:                $(x.σ)")
-    println(io, ident, "A²k statistic:            $(x.A²k)")
-    println(io, ident, "standardized statistic:   $((x.A²k - x.k + 1) / x.σ)")
-    println(io, ident, "modified test:            $(x.modified)")
-    println(io, ident, "p-value calculation:      $(x.nsim == 0 ? "asymptotic" : "simulation" )")
-    x.nsim != 0 && println(io, ident, "number of simulations:    $(x.nsim)")
+    println(io, ident, "number of samples:        ", x.k)
+    println(io, ident, "number of observations:   ", x.n)
+    println(io, ident, "SD of A²k:                ", x.σ)
+    println(io, ident, "A²k statistic:            ", x.A²k)
+    println(io, ident, "standardized statistic:   ", (x.A²k - x.k + 1) / x.σ)
+    println(io, ident, "modified test:            ", x.modified)
+    println(io, ident, "p-value calculation:      ", x.nsim == 0 ? "asymptotic" : "simulation" )
+    x.nsim != 0 && println(io, ident, "number of simulations:    ", x.nsim)
 end
 
 """Monte-Carlo simulation of the p-value for AD test"""

--- a/src/binomial.jl
+++ b/src/binomial.jl
@@ -62,8 +62,8 @@ population_param_of_interest(x::BinomialTest) = ("Probability of success", x.p, 
 default_tail(test::BinomialTest) = :both
 
 function show_params(io::IO, x::BinomialTest, ident="")
-    println(io, ident, "number of observations: $(x.n)")
-    println(io, ident, "number of successes:    $(x.x)")
+    println(io, ident, "number of observations: ", x.n)
+    println(io, ident, "number of successes:    ", x.x)
 end
 
 StatsAPI.pvalue(x::BinomialTest; tail=:both) = pvalue(Binomial(x.n, x.p), x.x; tail=tail)

--- a/src/circular.jl
+++ b/src/circular.jl
@@ -56,8 +56,8 @@ population_param_of_interest(x::RayleighTest) = ("Mean resultant length", 0, x.R
 default_tail(test::RayleighTest) = :both
 
 function show_params(io::IO, x::RayleighTest, ident="")
-    println(io, ident, "number of observations: $(x.n)")
-    println(io, ident, "test statistic:         $(x.Rbar^2 * x.n)")
+    println(io, ident, "number of observations: ", x.n)
+    println(io, ident, "test statistic:         ", x.Rbar^2 * x.n)
 end
 
 function StatsAPI.pvalue(x::RayleighTest)
@@ -215,7 +215,7 @@ population_param_of_interest(x::JammalamadakaCircularCorrelation) = ("Circular-c
 default_tail(test::JammalamadakaCircularCorrelation) = :both
 
 function show_params(io::IO, x::JammalamadakaCircularCorrelation, ident="")
-    println(io, ident, "test statistic: $(x.Z)")
+    println(io, ident, "test statistic: ", x.Z)
 end
 
 StatsAPI.pvalue(x::JammalamadakaCircularCorrelation; tail=:both) = pvalue(Normal(), x.Z; tail=tail)

--- a/src/clark_west.jl
+++ b/src/clark_west.jl
@@ -70,7 +70,7 @@ population_param_of_interest(x::ClarkWestTest) = ("Mean", x.μ0, x.xbar)
 default_tail(::ClarkWestTest) = :both
 
 function show_params(io::IO, x::ClarkWestTest, ident)
-    println(io, ident, "number of observations:    $(x.n)")
-    println(io, ident, "CW statistic:              $(x.z)")
-    println(io, ident, "population standard error: $(x.stderr)")
+    println(io, ident, "number of observations:    ", x.n)
+    println(io, ident, "CW statistic:              ", x.z)
+    println(io, ident, "population standard error: ", x.stderr)
 end

--- a/src/diebold_mariano.jl
+++ b/src/diebold_mariano.jl
@@ -74,7 +74,7 @@ population_param_of_interest(x::DieboldMarianoTest) = ("Mean", x.μ0, x.xbar)
 default_tail(test::DieboldMarianoTest) = :both
 
 function show_params(io::IO, x::DieboldMarianoTest, ident)
-    println(io, ident, "number of observations: $(x.n)")
-    println(io, ident, "DM statistic:           $(x.t)")
-    println(io, ident, "degrees of freedom:     $(x.df)")
+    println(io, ident, "number of observations: ", x.n)
+    println(io, ident, "DM statistic:           ", x.t)
+    println(io, ident, "degrees of freedom:     ", x.df)
 end

--- a/src/f.jl
+++ b/src/f.jl
@@ -59,7 +59,7 @@ default_tail(test::VarianceFTest) = :both
 
 function show_params(io::IO, x::VarianceFTest, ident)
     println(io, ident, "number of observations: [$(x.n_x), $(x.n_y)]")
-    println(io, ident, "F statistic:            $(x.F)")
+    println(io, ident, "F statistic:            ", x.F)
     println(io, ident, "degrees of freedom:     [$(x.df_x), $(x.df_y)]")
 end
 

--- a/src/kolmogorov_smirnov.jl
+++ b/src/kolmogorov_smirnov.jl
@@ -85,7 +85,7 @@ end
 testname(::ExactOneSampleKSTest) = "Exact one sample Kolmogorov-Smirnov test"
 
 function show_params(io::IO, x::ExactOneSampleKSTest, ident="")
-    println(io, ident, "number of observations:   $(x.n)")
+    println(io, ident, "number of observations:   ", x.n)
 end
 
 function StatsAPI.pvalue(x::ExactKSTest; tail=:both)
@@ -125,8 +125,8 @@ end
 testname(::ApproximateOneSampleKSTest) = "Approximate one sample Kolmogorov-Smirnov test"
 
 function show_params(io::IO, x::ApproximateOneSampleKSTest, ident="")
-    println(io, ident, "number of observations:   $(x.n)")
-    println(io, ident, "KS-statistic:             $(sqrt(x.n)*x.δ)")
+    println(io, ident, "number of observations:   ", x.n)
+    println(io, ident, "KS-statistic:             ", sqrt(x.n)*x.δ)
 end
 
 # one-sided: http://www.encyclopediaofmath.org/index.php/Kolmogorov-Smirnov_test
@@ -179,7 +179,7 @@ testname(::ApproximateTwoSampleKSTest) = "Approximate two sample Kolmogorov-Smir
 function show_params(io::IO, x::ApproximateTwoSampleKSTest, ident="")
     n = x.n_x*x.n_y/(x.n_x+x.n_y)
     println(io, ident, "number of observations:   [$(x.n_x),$(x.n_y)]")
-    println(io, ident, "KS-statistic:              $(sqrt(n)*x.δ)")
+    println(io, ident, "KS-statistic:              ", sqrt(n)*x.δ)
 end
 
 function StatsAPI.pvalue(x::ApproximateTwoSampleKSTest; tail=:both)

--- a/src/power_divergence.jl
+++ b/src/power_divergence.jl
@@ -439,9 +439,9 @@ MultinomialLRTest(x::AbstractVector{T}, theta0::Vector{U} = ones(length(x))/leng
     PowerDivergenceTest(reshape(x, length(x), 1), lambda=0.0, theta0=theta0)
 
 function show_params(io::IO, x::PowerDivergenceTest, ident="")
-    println(io, ident, "Sample size:        $(x.n)")
-    println(io, ident, "statistic:          $(x.stat)")
-    println(io, ident, "degrees of freedom: $(x.df)")
+    println(io, ident, "Sample size:        ", x.n)
+    println(io, ident, "statistic:          ", x.stat)
+    println(io, ident, "degrees of freedom: ", x.df)
     print(io, ident, "residuals:          ")
     show(io, vec(x.residuals))
     println(io)

--- a/src/t.jl
+++ b/src/t.jl
@@ -64,10 +64,10 @@ testname(::OneSampleTTest) = "One sample t-test"
 population_param_of_interest(x::OneSampleTTest) = ("Mean", x.μ0, x.xbar) # parameter of interest: name, value under h0, point estimate
 
 function show_params(io::IO, x::OneSampleTTest, ident="")
-    println(io, ident, "number of observations:   $(x.n)")
-    println(io, ident, "t-statistic:              $(x.t)")
-    println(io, ident, "degrees of freedom:       $(x.df)")
-    println(io, ident, "empirical standard error: $(x.stderr)")
+    println(io, ident, "number of observations:   ", x.n)
+    println(io, ident, "t-statistic:              ", x.t)
+    println(io, ident, "degrees of freedom:       ", x.df)
+    println(io, ident, "empirical standard error: ", x.stderr)
 end
 
 """
@@ -131,9 +131,9 @@ end
 
 function show_params(io::IO, x::TwoSampleTTest, ident="")
     println(io, ident, "number of observations:   [$(x.n_x),$(x.n_y)]")
-    println(io, ident, "t-statistic:              $(x.t)")
-    println(io, ident, "degrees of freedom:       $(x.df)")
-    println(io, ident, "empirical standard error: $(x.stderr)")
+    println(io, ident, "t-statistic:              ", x.t)
+    println(io, ident, "degrees of freedom:       ", x.df)
+    println(io, ident, "empirical standard error: ", x.stderr)
 end
 
 testname(::EqualVarianceTTest) = "Two sample t-test (equal variance)"

--- a/src/wald_wolfowitz.jl
+++ b/src/wald_wolfowitz.jl
@@ -16,8 +16,8 @@ StatsAPI.pvalue(test::WaldWolfowitzTest; tail=:both) = pvalue(Normal(0.0, 1.0), 
 
 
 function show_params(io::IO, x::WaldWolfowitzTest, ident="")
-    println(io, ident, "number of runs:  $(x.nruns)")
-    println(io, ident, "z-statistic:     $(x.z)")
+    println(io, ident, "number of runs:  ", x.nruns)
+    println(io, ident, "z-statistic:     ", x.z)
 end
 
 """

--- a/src/z.jl
+++ b/src/z.jl
@@ -63,9 +63,9 @@ testname(::OneSampleZTest) = "One sample z-test"
 population_param_of_interest(x::OneSampleZTest) = ("Mean", x.μ0, x.xbar) # parameter of interest: name, value under h0, point estimate
 
 function show_params(io::IO, x::OneSampleZTest, ident="")
-    println(io, ident, "number of observations:   $(x.n)")
-    println(io, ident, "z-statistic:              $(x.z)")
-    println(io, ident, "population standard error: $(x.stderr)")
+    println(io, ident, "number of observations:   ", x.n)
+    println(io, ident, "z-statistic:              ", x.z)
+    println(io, ident, "population standard error: ", x.stderr)
 end
 
 """
@@ -123,8 +123,8 @@ end
 
 function show_params(io::IO, x::TwoSampleZTest, ident="")
     println(io, ident, "number of observations:   [$(x.n_x),$(x.n_y)]")
-    println(io, ident, "z-statistic:              $(x.z)")
-    println(io, ident, "population standard error: $(x.stderr)")
+    println(io, ident, "z-statistic:              ", x.z)
+    println(io, ident, "population standard error: ", x.stderr)
 end
 
 testname(::EqualVarianceZTest) = "Two sample z-test (equal variance)"

--- a/test/show.jl
+++ b/test/show.jl
@@ -21,7 +21,7 @@ m = PowerDivergenceTest(d)
 
     Details:
         Sample size:        2757
-        statistic:          30.070149095754687
+        statistic:          30.0701
         degrees of freedom: 2
         residuals:          [2.19886, -2.50467, 0.41137, -0.468583, -2.84324, 3.23867]
         std. residuals:     [4.50205, -4.50205, 0.699452, -0.699452, -5.31595, 5.31595]
@@ -52,9 +52,7 @@ m = PowerDivergenceTest(d)
         std. residuals:     [0.0, -1.36931, 1.36931]
     """
 
-# based on t.jl tests. The two full-precision floats are interpolated rather than
-# spelled out: `std(-5:10)` moves by one ulp between Statistics 1.11.1 and 1.11.4,
-# and layout is what this test is for
+# based on t.jl tests
 tst = OneSampleTTest(-5:10)
 
 @test sprint(show, tst) ==
@@ -73,9 +71,9 @@ tst = OneSampleTTest(-5:10)
 
     Details:
         number of observations:   16
-        t-statistic:              $(tst.t)
+        t-statistic:              2.10042
         degrees of freedom:       15
-        empirical standard error: $(tst.stderr)
+        empirical standard error: 1.19024
     """
 
 # issue #248
@@ -135,8 +133,8 @@ tst = UnequalVarianceTTest(x, y)
 
     Details:
         number of observations:   [17,17]
-        t-statistic:              3.3767280623082523
-        degrees of freedom:       19.363987783845342
-        empirical standard error: 4.610162387563106e-8
+        t-statistic:              3.37673
+        degrees of freedom:       19.364
+        empirical standard error: 4.61016e-8
     """
 end

--- a/test/wald_wolfowitz.jl
+++ b/test/wald_wolfowitz.jl
@@ -29,7 +29,7 @@ using Distributions
 
     Details:
         number of runs:  2
-        z-statistic:     -31.575338477995764
+        z-statistic:     -31.5753
     """
     output = sprint(show, tst)
     @test output == expected_output
@@ -61,7 +61,7 @@ end
 
     Details:
         number of runs:  2
-        z-statistic:     -31.575338477995764
+        z-statistic:     -31.5753
     """
     output = sprint(show, tst)
     @test output == expected_output


### PR DESCRIPTION
`Base.show` for a `HypothesisTest` wraps the stream in an `IOContext` with `:compact => true`, which is why vectors such as residuals already print with six significant digits. Several `show_params` methods interpolated their scalars into the string instead, as in `"statistic: $(x.stat)"`. Interpolation formats the number before it reaches the stream, so the context is bypassed and statistics, standard errors and non-integer degrees of freedom printed with all seventeen digits, while the methods that pass the value as a `println` argument printed compactly.

This PR makes every `show_params` method pass its scalars as `println` arguments. Before and after for the power divergence test:

```
statistic:          30.070149095754687
statistic:          30.0701
```

Affected methods: Anderson-Darling (both), binomial, circular (both), Clark-West, Diebold-Mariano, F, Kolmogorov-Smirnov (all three), power divergence, t (both), Wald-Wolfowitz and z (both). Bracketed pairs of integer counts such as `[10,8]` are left as they were, since compact printing does not change integers.

The show tests and the t-test doctests are updated to the compact values. A side effect is that the show tests no longer encode the last bits of the statistic, so they stop breaking on harmless changes in floating-point evaluation order, which is what surfaced this in #392.

The full test suite and the doctests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)